### PR TITLE
Update transparency slider and emit annotationSelected signal

### DIFF
--- a/toolbox/QtAnnotation.py
+++ b/toolbox/QtAnnotation.py
@@ -293,6 +293,7 @@ class AnnotationWindow(QGraphicsView):
     toolChanged = pyqtSignal(str)  # Signal to emit when the tool changes
     labelSelected = pyqtSignal(str)  # Signal to emit when the label changes
     annotationSizeChanged = pyqtSignal(int)  # Signal to emit when annotation size changes
+    annotationSelected = pyqtSignal(int)  # Signal to emit when annotation is selected
 
     def __init__(self, main_window, parent=None):
         super().__init__(parent)
@@ -1434,6 +1435,8 @@ class AnnotationWindow(QGraphicsView):
             self.annotation_color = self.selected_annotation.label.color
             # Emit a signal indicating the selected annotations label to LabelWindow
             self.labelSelected.emit(annotation.label.id)
+            # Emit a signal indicating the selected annotation's transparency to MainWindow
+            self.annotationSelected.emit(annotation.transparency)
             # Crop the image from annotation using current image item
             if not self.selected_annotation.cropped_image:
                 self.selected_annotation.create_cropped_image(self.rasterio_image)

--- a/toolbox/QtMain.py
+++ b/toolbox/QtMain.py
@@ -82,6 +82,10 @@ class MainWindow(QMainWindow):
         self.image_window.imageSelected.connect(self.annotation_window.update_current_image_path)
         # Connect the labelSelected signal from LabelWindow to update the selected label in AnnotationWindow
         self.label_window.labelSelected.connect(self.annotation_window.set_selected_label)
+        # Connect the annotationSelected signal from AnnotationWindow to update the transparency slider
+        self.annotation_window.annotationSelected.connect(self.update_transparency_slider)
+        # Connect the labelSelected signal from LabelWindow to update the transparency slider
+        self.label_window.labelSelected.connect(self.update_transparency_slider)
 
         self.central_widget = QWidget()
         self.setCentralWidget(self.central_widget)
@@ -383,6 +387,10 @@ class MainWindow(QMainWindow):
     def update_annotation_transparency(self, value):
         if self.annotation_window.selected_label:
             self.annotation_window.update_annotations_transparency(self.annotation_window.selected_label, value)
+        self.transparency_slider.setValue(value)  # Update the slider value
+
+    def update_transparency_slider(self, transparency):
+        self.transparency_slider.setValue(transparency)
 
     def get_uncertainty_thresh(self):
         return self.uncertainty_thresh


### PR DESCRIPTION
* **toolbox/QtMain.py**
  - Connect `annotationSelected` signal from `AnnotationWindow` and `labelSelected` signal from `LabelWindow` to `update_transparency_slider`
  - Update `update_annotation_transparency` method to set the slider value
  - Add `update_transparency_slider` method to set the slider value

* **toolbox/QtAnnotation.py**
  - Add `annotationSelected` signal in `AnnotationWindow` class
  - Emit `annotationSelected` signal in `select_annotation` method