### PR TITLE
Add tile dataset dialog

### DIFF
--- a/coralnet_toolbox/MachineLearning/TileDataset/QtDetect.py
+++ b/coralnet_toolbox/MachineLearning/TileDataset/QtDetect.py
@@ -29,15 +29,27 @@ class Detect(Base):
         """
         Perform batch inference on the selected images.
         """
-        self.loaded_model = self.deploy_model_dialog.loaded_model
-        
-        # Make predictions on each image's annotations
-        progress_bar = ProgressBar(self, title="")
-        progress_bar.show()
-        progress_bar.start_progress(len(self.image_paths))
+        src = self.src_edit.text()
+        dst = self.dst_edit.text()
 
-        if self.loaded_model is not None:
-            self.deploy_model_dialog.predict(inputs=self.image_paths)
+        config = TileConfig(
+            slice_wh=eval(self.slice_wh_edit.text()),
+            overlap_wh=eval(self.overlap_wh_edit.text()),
+            ext=self.ext_edit.text(),
+            annotation_type=self.annotation_type_combo.currentText(),
+            densify_factor=self.densify_factor_spinbox.value(),
+            smoothing_tolerance=self.smoothing_tolerance_spinbox.value(),
+            train_ratio=self.train_ratio_spinbox.value(),
+            valid_ratio=self.valid_ratio_spinbox.value(),
+            test_ratio=self.test_ratio_spinbox.value(),
+            margins=eval(self.margins_edit.text())
+        )
 
-        progress_bar.stop_progress()
-        progress_bar.close()
+        tiler = YoloTiler(
+            source=src,
+            target=dst,
+            config=config,
+            num_viz_samples=15,
+        )
+
+        tiler.run()

--- a/coralnet_toolbox/MachineLearning/TileDataset/QtSegment.py
+++ b/coralnet_toolbox/MachineLearning/TileDataset/QtSegment.py
@@ -29,15 +29,27 @@ class Segment(Base):
         """
         Perform batch inference on the selected images.
         """
-        self.loaded_model = self.deploy_model_dialog.loaded_model
-        
-        # Make predictions on each image's annotations
-        progress_bar = ProgressBar(self, title="")
-        progress_bar.show()
-        progress_bar.start_progress(len(self.image_paths))
+        src = self.src_edit.text()
+        dst = self.dst_edit.text()
 
-        if self.loaded_model is not None:
-            self.deploy_model_dialog.predict(inputs=self.image_paths)
+        config = TileConfig(
+            slice_wh=eval(self.slice_wh_edit.text()),
+            overlap_wh=eval(self.overlap_wh_edit.text()),
+            ext=self.ext_edit.text(),
+            annotation_type=self.annotation_type_combo.currentText(),
+            densify_factor=self.densify_factor_spinbox.value(),
+            smoothing_tolerance=self.smoothing_tolerance_spinbox.value(),
+            train_ratio=self.train_ratio_spinbox.value(),
+            valid_ratio=self.valid_ratio_spinbox.value(),
+            test_ratio=self.test_ratio_spinbox.value(),
+            margins=eval(self.margins_edit.text())
+        )
 
-        progress_bar.stop_progress()
-        progress_bar.close()
+        tiler = YoloTiler(
+            source=src,
+            target=dst,
+            config=config,
+            num_viz_samples=15,
+        )
+
+        tiler.run()


### PR DESCRIPTION
Implement the dialog for the TileDataset QtBase's Base class to allow user input for YoloTiler and TileConfig parameters.

* Add input fields for source and destination directories, tile size, overlap, image extension, annotation type, densify factor, smoothing tolerance, train ratio, validation ratio, test ratio, and margins in `setup_task_specific_layout` method in `coralnet_toolbox/MachineLearning/TileDataset/QtBase.py`.
* Implement `batch_inference` method in `coralnet_toolbox/MachineLearning/TileDataset/QtBase.py` to use the provided parameters for YoloTiler and TileConfig.
* Add methods to browse and select source and destination directories, and validate the source directory in `coralnet_toolbox/MachineLearning/TileDataset/QtBase.py`.
* Update `batch_inference` method in `coralnet_toolbox/MachineLearning/TileDataset/QtDetect.py` to use the provided parameters for YoloTiler and TileConfig.
* Update `batch_inference` method in `coralnet_toolbox/MachineLearning/TileDataset/QtSegment.py` to use the provided parameters for YoloTiler and TileConfig.

