### PR TITLE
Fix tile dataset validation

### DIFF
--- a/coralnet_toolbox/MachineLearning/TileDataset/QtBase.py
+++ b/coralnet_toolbox/MachineLearning/TileDataset/QtBase.py
@@ -8,7 +8,7 @@ from yolo_tiler import YoloTiler, TileConfig
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QApplication, QMessageBox, QCheckBox, QVBoxLayout,
                              QLabel, QDialog, QDialogButtonBox, QGroupBox, QButtonGroup,
-                             QFormLayout, QLineEdit, QDoubleSpinBox, QComboBox, QPushButton, QFileDialog)
+                             QFormLayout, QLineEdit, QDoubleSpinBox, QComboBox, QPushButton, QFileDialog, QSpinBox)
 
 from coralnet_toolbox.Icons import get_icon
 
@@ -80,7 +80,9 @@ class Base(QDialog):
         src_layout.addWidget(self.src_button)
         layout.addRow("Source Directory:", src_layout)
 
-        # TODO Name of Destination Dataset edit text
+        # Name of Destination Dataset
+        self.dst_name_edit = QLineEdit()
+        layout.addRow("Name of Destination Dataset:", self.dst_name_edit)
 
         # Destination Directory
         self.dst_edit = QLineEdit()
@@ -109,9 +111,11 @@ class Base(QDialog):
         self.overlap_wh_edit = QLineEdit()
         layout.addRow("Overlap (width, height):", self.overlap_wh_edit)
 
-        # Image Extension TODO Convert to editable dropdown with pre-filled (.png, .tif, .jpeg, .jpg)
-        self.ext_edit = QLineEdit()
-        layout.addRow("Image Extension:", self.ext_edit)
+        # Image Extension
+        self.ext_combo = QComboBox()
+        self.ext_combo.addItems([".png", ".tif", ".jpeg", ".jpg"])
+        self.ext_combo.setEditable(True)
+        layout.addRow("Image Extension:", self.ext_combo)
 
         # Densify Factor
         self.densify_factor_spinbox = QDoubleSpinBox()
@@ -144,6 +148,11 @@ class Base(QDialog):
         # Margins
         self.margins_edit = QLineEdit()
         layout.addRow("Margins:", self.margins_edit)
+
+        # Number of Visualization Samples
+        self.num_viz_sample_spinbox = QSpinBox()
+        self.num_viz_sample_spinbox.setRange(1, 100)
+        layout.addRow("Number of Visualization Samples:", self.num_viz_sample_spinbox)
 
         group_box.setLayout(layout)
         self.layout.addWidget(group_box)
@@ -186,6 +195,95 @@ class Base(QDialog):
             QMessageBox.warning(self, "Invalid Source Directory", "The source directory must contain a 'train' sub-folder.")
             return False
         return True
+
+    def validate_slice_wh(self, slice_wh):
+        """
+        Validate the slice_wh parameter to ensure it is a tuple of two integers.
+        
+        :param slice_wh: Slice width and height
+        :return: True if valid, False otherwise
+        """
+        if not isinstance(slice_wh, tuple) or len(slice_wh) != 2 or not all(isinstance(i, int) for i in slice_wh):
+            QMessageBox.warning(self, "Invalid Tile Size", "The tile size must be a tuple of two integers.")
+            return False
+        return True
+
+    def validate_overlap_wh(self, overlap_wh):
+        """
+        Validate the overlap_wh parameter to ensure it is a tuple of two floats.
+        
+        :param overlap_wh: Overlap width and height
+        :return: True if valid, False otherwise
+        """
+        if not isinstance(overlap_wh, tuple) or len(overlap_wh) != 2 or not all(isinstance(i, (int, float)) for i in overlap_wh):
+            QMessageBox.warning(self, "Invalid Overlap", "The overlap must be a tuple of two floats.")
+            return False
+        return True
+
+    def validate_ext(self, ext):
+        """
+        Validate the ext parameter to ensure it is a string and starts with a dot.
+        
+        :param ext: Image file extension
+        :return: True if valid, False otherwise
+        """
+        if not isinstance(ext, str) or not ext.startswith('.'):
+            QMessageBox.warning(self, "Invalid Image Extension", "The image extension must be a string starting with a dot.")
+            return False
+        return True
+
+    def validate_densify_factor(self, densify_factor):
+        """
+        Validate the densify_factor parameter to ensure it is a float between 0 and 1.
+        
+        :param densify_factor: Densify factor
+        :return: True if valid, False otherwise
+        """
+        if not isinstance(densify_factor, float) or not (0.0 <= densify_factor <= 1.0):
+            QMessageBox.warning(self, "Invalid Densify Factor", "The densify factor must be a float between 0 and 1.")
+            return False
+        return True
+
+    def validate_smoothing_tolerance(self, smoothing_tolerance):
+        """
+        Validate the smoothing_tolerance parameter to ensure it is a float between 0 and 1.
+        
+        :param smoothing_tolerance: Smoothing tolerance
+        :return: True if valid, False otherwise
+        """
+        if not isinstance(smoothing_tolerance, float) or not (0.0 <= smoothing_tolerance <= 1.0):
+            QMessageBox.warning(self, "Invalid Smoothing Tolerance", "The smoothing tolerance must be a float between 0 and 1.")
+            return False
+        return True
+
+    def validate_ratios(self, train_ratio, valid_ratio, test_ratio):
+        """
+        Validate the train_ratio, valid_ratio, and test_ratio parameters to ensure they are floats between 0 and 1 and sum to 1.
+        
+        :param train_ratio: Train ratio
+        :param valid_ratio: Validation ratio
+        :param test_ratio: Test ratio
+        :return: True if valid, False otherwise
+        """
+        if not all(isinstance(ratio, float) and 0.0 <= ratio <= 1.0 for ratio in [train_ratio, valid_ratio, test_ratio]):
+            QMessageBox.warning(self, "Invalid Ratios", "The train, validation, and test ratios must be floats between 0 and 1.")
+            return False
+        if not abs(train_ratio + valid_ratio + test_ratio - 1.0) < 1e-9:
+            QMessageBox.warning(self, "Invalid Ratios", "The train, validation, and test ratios must sum to 1.")
+            return False
+        return True
+
+    def validate_margins(self, margins):
+        """
+        Validate the margins parameter to ensure it is a tuple of four integers.
+        
+        :param margins: Margins
+        :return: True if valid, False otherwise
+        """
+        if not isinstance(margins, tuple) or len(margins) != 4 or not all(isinstance(i, (int, float)) for i in margins):
+            QMessageBox.warning(self, "Invalid Margins", "The margins must be a tuple of four integers.")
+            return False
+        return True
     
     def apply(self):
         """
@@ -211,8 +309,7 @@ class Base(QDialog):
         Use yolo-tiling to tile the dataset.
         """
         src = self.src_edit.text()
-        dst = self.dst_edit.text()
-        # TODO dst = dst + Name of Destination Dataset
+        dst = os.path.join(self.dst_edit.text(), self.dst_name_edit.text())
 
         # -------------------------
         # Perform validation checks
@@ -220,28 +317,65 @@ class Base(QDialog):
         # Check the directory has a 'train' folder
         if not self.validate_source_directory(src):
             return
-        
-        # TODO Perform the other checks here
+
+        # Validate the slice_wh parameter
+        slice_wh = eval(self.slice_wh_edit.text())
+        if not self.validate_slice_wh(slice_wh):
+            return
+
+        # Validate the overlap_wh parameter
+        overlap_wh = eval(self.overlap_wh_edit.text())
+        if not self.validate_overlap_wh(overlap_wh):
+            return
+
+        # Validate the ext parameter
+        ext = self.ext_combo.currentText()
+        if not self.validate_ext(ext):
+            return
+
+        # Validate the densify_factor parameter
+        densify_factor = self.densify_factor_spinbox.value()
+        if not self.validate_densify_factor(densify_factor):
+            return
+
+        # Validate the smoothing_tolerance parameter
+        smoothing_tolerance = self.smoothing_tolerance_spinbox.value()
+        if not self.validate_smoothing_tolerance(smoothing_tolerance):
+            return
+
+        # Validate the train_ratio, valid_ratio, and test_ratio parameters
+        train_ratio = self.train_ratio_spinbox.value()
+        valid_ratio = self.valid_ratio_spinbox.value()
+        test_ratio = self.test_ratio_spinbox.value()
+        if not self.validate_ratios(train_ratio, valid_ratio, test_ratio):
+            return
+
+        # Validate the margins parameter
+        margins = eval(self.margins_edit.text())
+        if not self.validate_margins(margins):
+            return
+
+        # Get the number of visualization samples
+        num_viz_samples = self.num_viz_sample_spinbox.value()
 
         config = TileConfig(
-            slice_wh=eval(self.slice_wh_edit.text()),
-            overlap_wh=eval(self.overlap_wh_edit.text()),
-            ext=self.ext_edit.text(),
+            slice_wh=slice_wh,
+            overlap_wh=overlap_wh,
+            ext=ext,
             annotation_type=self.annotation_type,
-            densify_factor=self.densify_factor_spinbox.value(),
-            smoothing_tolerance=self.smoothing_tolerance_spinbox.value(),
-            train_ratio=self.train_ratio_spinbox.value(),
-            valid_ratio=self.valid_ratio_spinbox.value(),
-            test_ratio=self.test_ratio_spinbox.value(),
-            margins=eval(self.margins_edit.text())
+            densify_factor=densify_factor,
+            smoothing_tolerance=smoothing_tolerance,
+            train_ratio=train_ratio,
+            valid_ratio=valid_ratio,
+            test_ratio=test_ratio,
+            margins=margins
         )
 
         tiler = YoloTiler(
             source=src,
             target=dst,
             config=config,
-            num_viz_samples=int(self.num_viz_samples.value()), # TODO
+            num_viz_samples=num_viz_samples,  # Number of samples to visualize
         )
 
         tiler.run()
-


### PR DESCRIPTION
Resolve the TODOs in the `coralnet_toolbox/MachineLearning/TileDataset/QtBase.py` class and add validation for specified parameters.

* **Add Destination Dataset Name Field**
  - Add a text field for the name of the destination dataset.

* **Add Editable Dropdown for Image Extension**
  - Convert the image extension field to an editable dropdown with pre-filled options (.png, .tif, .jpeg, .jpg).

* **Add Number of Visualization Samples Field**
  - Add a spin box to allow the user to specify the number of visualization samples.

* **Add Validation Methods**
  - Add validation methods for `slice_wh`, `overlap_wh`, `ext`, `densify_factor`, `smoothing_tolerance`, `train_ratio`, `valid_ratio`, `test_ratio`, and `margins`.

* **Update Apply Method**
  - Update the `apply` method to perform validation checks for the specified parameters before tiling the dataset.
  - Update the `apply` method to include the new destination dataset name and number of visualization samples.

