### PR TITLE
Update annotation filtering based on selected image option

### DIFF
--- a/coralnet_toolbox/MachineLearning/ExportDataset/QtBase.py
+++ b/coralnet_toolbox/MachineLearning/ExportDataset/QtBase.py
@@ -360,6 +360,10 @@ class Base(QDialog):
 
         # Filter annotations based on the selected labels
         annotations = [a for a in filtered_annotations if a.label.short_label_code in self.selected_labels]
+
+        # Filter annotations based on the selected image option
+        if self.filtered_images_radio.isChecked():
+            annotations = [a for a in annotations if a.image_path in self.image_window.filtered_image_paths]
         
         return annotations
 
@@ -677,4 +681,5 @@ class Base(QDialog):
         """
         Update the table based on the selected image option.
         """
+        self.selected_annotations = self.filter_annotations()
         self.update_summary_statistics()


### PR DESCRIPTION
Update `Base` class in `coralnet_toolbox/MachineLearning/ExportDataset/QtBase.py` to use annotations from all images or only from filtered images based on checkbox selection.

* **Filter Annotations**: Add logic to `filter_annotations` method to filter annotations based on the selected image option (all images or filtered images).
* **Update Image Selection**: Modify `update_image_selection` method to filter annotations based on the selected image option before calling `update_summary_statistics`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jordan-Pierce/CoralNet-Toolbox/pull/106?shareId=19f40399-9808-4ba6-9632-e21810404582).