### PR TITLE
Add import TagLab Labels (.JSON) feature

### DIFF
--- a/coralnet_toolbox/IO/ImportTagLabLabels.py
+++ b/coralnet_toolbox/IO/ImportTagLabLabels.py
@@ -1,0 +1,55 @@
+import json
+import warnings
+
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
+
+from coralnet_toolbox.QtLabelWindow import Label
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+class ImportTagLabLabels:
+    def __init__(self, main_window):
+        self.main_window = main_window
+        self.label_window = main_window.label_window
+
+    def import_taglab_labels(self):
+        self.main_window.untoggle_all_tools()
+
+        options = QFileDialog.Options()
+        file_path, _ = QFileDialog.getOpenFileName(self.label_window,
+                                                   "Import TagLab Labels",
+                                                   "",
+                                                   "JSON Files (*.json);;All Files (*)",
+                                                   options=options)
+        if file_path:
+            try:
+                with open(file_path, 'r') as file:
+                    data = json.load(file)
+
+                if 'labels' not in data:
+                    QMessageBox.warning(self.label_window,
+                                        "Invalid JSON Format",
+                                        "The selected JSON file does not contain 'labels' key.")
+                    return
+
+                for label_id, label_info in data['labels'].items():
+                    short_label_code = label_info['name'].strip()
+                    long_label_code = label_info['name'].strip()
+                    color = label_info['fill']
+
+                    label = Label(short_label_code, long_label_code, color, label_id)
+                    if not self.label_window.label_exists(label.short_label_code, label.long_label_code):
+                        self.label_window.add_label(label.short_label_code,
+                                                    label.long_label_code,
+                                                    label.color,
+                                                    label.id)
+
+                QMessageBox.information(self.label_window,
+                                        "Labels Imported",
+                                        "TagLab labels have been successfully imported.")
+
+            except Exception as e:
+                QMessageBox.warning(self.label_window,
+                                    "Error Importing Labels",
+                                    f"An error occurred while importing TagLab labels: {str(e)}")

--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -39,7 +39,8 @@ from coralnet_toolbox.IO import (
     ExportAnnotations,
     ExportCoralNetAnnotations,
     ExportViscoreAnnotations,
-    ExportTagLabAnnotations
+    ExportTagLabAnnotations,
+    ImportTagLabLabels  # Import the new class
 )
 
 from coralnet_toolbox.MachineLearning import (
@@ -151,6 +152,7 @@ class MainWindow(QMainWindow):
         self.export_coralnet_annotations = ExportCoralNetAnnotations(self)
         self.export_viscore_annotations = ExportViscoreAnnotations(self)
         self.export_taglab_annotations = ExportTagLabAnnotations(self)
+        self.import_taglab_labels = ImportTagLabLabels(self)  # Create an instance of the new class
 
         # Create dialogs (Sample)
         self.patch_annotation_sampling_dialog = PatchSamplingDialog(self)
@@ -245,6 +247,11 @@ class MainWindow(QMainWindow):
         self.import_labels_action = QAction("Labels (JSON)", self)
         self.import_labels_action.triggered.connect(self.import_labels.import_labels)
         self.import_labels_menu.addAction(self.import_labels_action)
+
+        # Import TagLab Labels
+        self.import_taglab_labels_action = QAction("TagLab Labels (JSON)", self)
+        self.import_taglab_labels_action.triggered.connect(self.import_taglab_labels.import_taglab_labels)
+        self.import_labels_menu.addAction(self.import_taglab_labels_action)
 
         # Annotations submenu
         self.import_annotations_menu = self.import_menu.addMenu("Annotations")
@@ -770,7 +777,7 @@ class MainWindow(QMainWindow):
 
     def changeEvent(self, event):
         super().changeEvent(event)
-        if event.type() == QEvent.WindowStateChange:
+        if (event.type() == QEvent.WindowStateChange):
             if self.windowState() & Qt.WindowMinimized:
                 # Allow minimizing
                 pass


### PR DESCRIPTION
Add functionality to import TagLab labels from JSON files.

* Create a new class `ImportTagLabLabels` in `coralnet_toolbox/IO/ImportTagLabLabels.py` to handle importing TagLab labels.
* Add a method `import_taglab_labels` in `ImportTagLabLabels` to read and parse TagLab JSON files.
* Use `QFileDialog` to select the JSON file and `QMessageBox` to show success or error messages in `ImportTagLabLabels`.
* Add a new action `import_taglab_labels_action` in the `import_labels_menu` in `coralnet_toolbox/QtMainWindow.py` to import "TagLab Labels (.JSON)".
* Connect the new action to the `import_taglab_labels` method in the `ImportTagLabLabels` class in `coralnet_toolbox/QtMainWindow.py`.

