### PR TITLE
Add export TagLab labels functionality

### DIFF
--- a/coralnet_toolbox/IO/QtExportTagLabLabels.py
+++ b/coralnet_toolbox/IO/QtExportTagLabLabels.py
@@ -1,0 +1,64 @@
+import json
+import warnings
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QFileDialog, QMessageBox, QApplication
+
+from coralnet_toolbox.QtProgressBar import ProgressBar
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+class ExportTagLabLabels:
+    def __init__(self, main_window):
+        self.main_window = main_window
+        self.label_window = main_window.label_window
+
+    def export_taglab_labels(self):
+        self.main_window.untoggle_all_tools()
+
+        options = QFileDialog.Options()
+        file_path, _ = QFileDialog.getSaveFileName(self.label_window,
+                                                   "Export TagLab Labels",
+                                                   "",
+                                                   "JSON Files (*.json);;All Files (*)",
+                                                   options=options)
+        if file_path:
+            QApplication.setOverrideCursor(Qt.WaitCursor)
+            total_labels = len(self.label_window.labels)
+            progress_bar = ProgressBar(self.label_window, "Exporting TagLab Labels")
+            progress_bar.show()
+            progress_bar.start_progress(total_labels)
+
+            try:
+                labels_data = []
+                for label in self.label_window.labels:
+                    label_dict = {
+                        'name': label.short_label_code,
+                        'fill': label.color.getRgb()[:3],
+                        'border': [200, 200, 200],
+                        'visible': True
+                    }
+                    labels_data.append(label_dict)
+                    progress_bar.update_progress()
+
+                taglab_data = {
+                    'labels': labels_data
+                }
+
+                with open(file_path, 'w') as file:
+                    json.dump(taglab_data, file, indent=4)
+
+                QMessageBox.information(self.label_window,
+                                        "Labels Exported",
+                                        "TagLab labels have been successfully exported.")
+
+            except Exception as e:
+                QMessageBox.warning(self.label_window,
+                                    "Error Exporting Labels",
+                                    f"An error occurred while exporting TagLab labels: {str(e)}")
+
+            finally:
+                QApplication.restoreOverrideCursor()
+                progress_bar.stop_progress()
+                progress_bar.close()

--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -41,6 +41,7 @@ from coralnet_toolbox.IO import (
     ExportCoralNetAnnotations,
     ExportViscoreAnnotations,
     ExportTagLabAnnotations,
+    ExportTagLabLabels
 )
 
 from coralnet_toolbox.MachineLearning import (
@@ -149,6 +150,7 @@ class MainWindow(QMainWindow):
         self.import_viscore_annotations = ImportViscoreAnnotations(self)
         self.import_taglab_annotations = ImportTagLabAnnotations(self)
         self.export_labels = ExportLabels(self)
+        self.export_taglab_labels = ExportTagLabLabels(self)
         self.export_annotations = ExportAnnotations(self)
         self.export_coralnet_annotations = ExportCoralNetAnnotations(self)
         self.export_viscore_annotations = ExportViscoreAnnotations(self)
@@ -299,6 +301,11 @@ class MainWindow(QMainWindow):
         self.export_labels_action = QAction("Labels (JSON)", self)
         self.export_labels_action.triggered.connect(self.export_labels.export_labels)
         self.export_labels_menu.addAction(self.export_labels_action)
+
+        # Export TagLab Labels
+        self.export_taglab_labels_action = QAction("TagLab Labels (JSON)", self)
+        self.export_taglab_labels_action.triggered.connect(self.export_taglab_labels.export_taglab_labels)
+        self.export_labels_menu.addAction(self.export_taglab_labels_action)
 
         # Annotations submenu
         self.export_annotations_menu = self.export_menu.addMenu("Annotations")


### PR DESCRIPTION
Add functionality to export TagLab labels to a JSON file and integrate it into the main window.

* **`coralnet_toolbox/IO/QtExportTagLabLabels.py`**:
  - Import necessary modules and classes.
  - Define the `ExportTagLabLabels` class with an `__init__` method.
  - Implement the `export_taglab_labels` method to handle exporting labels to a JSON file.
  - Use `QFileDialog` to get the save file path and `json.dump` to write the labels to the file.

* **`coralnet_toolbox/QtMainWindow.py`**:
  - Import `ExportTagLabLabels` at the top of the file.
  - Add an action for exporting TagLab labels to the `export_labels_menu` in the `__init__` method.
  - Connect the action to the `export_taglab_labels` method in `ExportTagLabLabels`.

