### PR TITLE
Enhance checkboxes and optimize deletion

### DIFF
--- a/coralnet_toolbox/QtImageWindow.py
+++ b/coralnet_toolbox/QtImageWindow.py
@@ -250,6 +250,7 @@ class ImageWindow(QWidget):
             # Add checkbox
             checkbox = QCheckBox()
             checkbox.setStyleSheet("margin-left:10px;")
+            checkbox.setFixedSize(20, 20)  # Increase the size of the checkbox
             self.tableWidget.setCellWidget(row_position, 0, checkbox)
 
             item_text = f"{self.image_dict[path]['filename']}"
@@ -787,8 +788,10 @@ class ImageWindow(QWidget):
                                      QMessageBox.Yes | QMessageBox.No)
         
         if reply == QMessageBox.Yes:
+            self.annotation_window.blockSignals(True)  # Block signals to prevent new images from being loaded
             for path in selected_paths:
                 self.delete_image(path)
+            self.annotation_window.blockSignals(False)  # Unblock signals after deletion
 
     def delete_selected_annotations(self):
         selected_paths = self._get_selected_image_paths()
@@ -802,7 +805,9 @@ class ImageWindow(QWidget):
                                      QMessageBox.Yes | QMessageBox.No)
         
         if reply == QMessageBox.Yes:
+            self.annotation_window.blockSignals(True)  # Block signals to prevent new images from being loaded
             for path in selected_paths:
                 self.annotation_window.delete_image_annotations(path)
+            self.annotation_window.blockSignals(False)  # Unblock signals after deletion
             self.main_window.confidence_window.clear_display()
             self.update_table_widget()


### PR DESCRIPTION
Increase the size of the checkboxes under the "Select" row and prevent new images from being loaded when multiple images are deleted.

* Increase the size of the checkboxes in the `update_table_widget` method by setting a fixed size of 20x20.
* Modify the `delete_selected_images` method to block signals and prevent new images from being loaded during deletion.
* Modify the `delete_selected_annotations` method to block signals and prevent new images from being loaded during deletion.

