### PR TITLE
Add version to title window

### DIFF
--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -94,7 +94,7 @@ class MainWindow(QMainWindow):
     iouChanged = pyqtSignal(float)  # Signal to emit the current IoU threshold
     areaChanged = pyqtSignal(float, float)  # Signal to emit the current area threshold
 
-    def __init__(self):
+    def __init__(self, version):
         super().__init__()
 
         # Define icons
@@ -120,7 +120,7 @@ class MainWindow(QMainWindow):
         self.unlock_icon = get_icon("unlock.png")
 
         # Set the title and icon for the main window
-        self.setWindowTitle("CoralNet-Toolbox")
+        self.setWindowTitle(f"CoralNet-Toolbox v{version}")
         self.setWindowIcon(self.coral_icon)
 
         # Set window flags for resizing, minimize, maximize, and customizing

--- a/coralnet_toolbox/__init__.py
+++ b/coralnet_toolbox/__init__.py
@@ -6,3 +6,6 @@ __version__ = "0.0.26"
 __author__ = "Jordan Pierce"
 __email__ = "jordan.pierce@noaa.gov"
 __credits__ = "National Center for Coastal and Ocean Sciences (NCCOS)"
+
+def get_version():
+    return __version__

--- a/coralnet_toolbox/main.py
+++ b/coralnet_toolbox/main.py
@@ -4,6 +4,7 @@ from PyQt5.QtWidgets import QApplication
 
 from coralnet_toolbox.QtMainWindow import MainWindow
 from coralnet_toolbox.utilities import console_user
+from coralnet_toolbox import get_version
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -15,7 +16,7 @@ def run():
     try:
         app = QApplication([])
         app.setStyle('WindowsXP')
-        main_window = MainWindow()
+        main_window = MainWindow(version=get_version())
         main_window.show()
         app.exec_()
 


### PR DESCRIPTION
Add version display to the title window in `QtMainWindow.py`.

* **coralnet_toolbox/__init__.py**
  - Add `get_version()` function to return `__version__`.

* **coralnet_toolbox/main.py**
  - Import `get_version` from `coralnet_toolbox`.
  - Pass `get_version()` to `MainWindow` constructor.

* **coralnet_toolbox/QtMainWindow.py**
  - Add `version` parameter to `MainWindow` constructor.
  - Update the window title to include the `version`.

