### PR TITLE
Replace pandas with polars

### DIFF
--- a/coralnet_toolbox/IO/QtExportCoralNetAnnotations.py
+++ b/coralnet_toolbox/IO/QtExportCoralNetAnnotations.py
@@ -1,6 +1,6 @@
 import warnings
 
-import pandas as pd
+import polars as pl
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QFileDialog, QApplication, QMessageBox)
 
@@ -47,8 +47,8 @@ class ExportCoralNetAnnotations:
                     df.append(annotation.to_coralnet())
                     progress_bar.update_progress()
 
-                df = pd.DataFrame(df)
-                df.to_csv(file_path, index=False)
+                df = pl.DataFrame(df)
+                df.write_csv(file_path)
 
                 QMessageBox.information(self.annotation_window,
                                         "Annotations Exported",

--- a/coralnet_toolbox/IO/QtExportViscoreAnnotations.py
+++ b/coralnet_toolbox/IO/QtExportViscoreAnnotations.py
@@ -2,7 +2,7 @@ import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 import os
-import pandas as pd
+import polars as pl
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QFileDialog, QApplication, QMessageBox, QDialog, 
@@ -185,8 +185,8 @@ class ExportViscoreAnnotations(QDialog):
                 df = self.multiview_voting(dots_dict, progress_bar)
 
             # Save to CSV
-            df = pd.DataFrame(df)
-            df.to_csv(file_path, index=False)
+            df = pl.DataFrame(df)
+            df.write_csv(file_path)
 
             QMessageBox.information(self, 
                                     "Success",

--- a/coralnet_toolbox/MachineLearning/ConfusionMatrix.py
+++ b/coralnet_toolbox/MachineLearning/ConfusionMatrix.py
@@ -4,7 +4,7 @@ import seaborn as sns
 from matplotlib.ticker import FuncFormatter
 import os
 import json
-import pandas as pd
+import polars as pl
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -300,8 +300,8 @@ class ConfusionMatrixMetrics:
             'Class Distribution (%)': self.class_distributions * 100,
         }
 
-        df = pd.DataFrame(metrics_dict)
-        df.to_csv(os.path.join(directory, filename), index=False, float_format='%.4f')
+        df = pl.DataFrame(metrics_dict)
+        df.write_csv(os.path.join(directory, filename))
 
     def save_results(self, directory):
         """

--- a/coralnet_toolbox/MachineLearning/ExportDataset/QtClassify.py
+++ b/coralnet_toolbox/MachineLearning/ExportDataset/QtClassify.py
@@ -7,7 +7,7 @@ import os
 from operator import attrgetter
 from itertools import groupby
 
-import pandas as pd
+import polars as pl
 
 from PyQt5.QtWidgets import (QGroupBox, QVBoxLayout, QLabel)
 
@@ -83,7 +83,7 @@ class Classify(Base):
         for annotation in self.selected_annotations:
             df.append(annotation.to_coralnet())
 
-        pd.DataFrame(df).to_csv(f"{output_dir_path}/dataset.csv", index=False)
+        pl.DataFrame(df).write_csv(f"{output_dir_path}/dataset.csv")
         
     def process_annotations(self, annotations, split_dir, split):
         # Get unique image paths

--- a/scripts/Raw_Predictions.py
+++ b/scripts/Raw_Predictions.py
@@ -1,6 +1,6 @@
 import argparse
 from pathlib import Path
-import pandas as pd
+import polars as pl
 from ultralytics import YOLO
 from tqdm import tqdm
 from datetime import datetime
@@ -85,11 +85,11 @@ def main():
         results_data.append(row_data)
     
     # Create DataFrame
-    df = pd.DataFrame(results_data)
+    df = pl.DataFrame(results_data)
     
     # Save results
     output_path = f"{args.output_dir}/{get_now()}_predictions.csv"
-    df.to_csv(output_path, index=False)
+    df.write_csv(output_path)
     print(f"Results saved to {output_path}")
 
 

--- a/scripts/Subset_Dataset.py
+++ b/scripts/Subset_Dataset.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import argparse
 import matplotlib.pyplot as plt
-import pandas as pd
+import polars as pl
 from tqdm import tqdm
 
 
@@ -59,7 +59,7 @@ def plot_distribution(dst_dir, dataset_type):
         dataset_type (str): Type of dataset (e.g., 'train', 'valid', 'test').
     """
     class_counts = count_images_per_class(os.path.join(dst_dir, dataset_type))
-    df = pd.DataFrame(list(class_counts.items()), columns=['Class', 'Count'])
+    df = pl.DataFrame(list(class_counts.items()), columns=['Class', 'Count'])
 
     plt.figure(figsize=(10, 6))
     colors = plt.cm.tab20.colors  # Use a colormap with discrete colors


### PR DESCRIPTION
Replace the use of the `pandas` library with the `polars` library across multiple files for improved performance and efficiency.

* **coralnet_toolbox/IO/QtExportCoralNetAnnotations.py**
  - Replace `pandas` import with `polars`
  - Update DataFrame creation and CSV export methods

* **coralnet_toolbox/IO/QtImportCoralNetAnnotations.py**
  - Replace `pandas` import with `polars`
  - Update CSV reading and DataFrame operations to use `polars` syntax

* **coralnet_toolbox/MachineLearning/ConfusionMatrix.py**
  - Replace `pandas` import with `polars`
  - Update DataFrame creation and CSV export methods

* **scripts/Raw_Predictions.py**
  - Replace `pandas` import with `polars`
  - Update DataFrame creation and CSV export methods

* **scripts/Subset_Dataset.py**
  - Replace `pandas` import with `polars`
  - Update DataFrame creation and plotting methods

* **coralnet_toolbox/IO/QtImportViscoreAnnotations.py**
  - Replace `pandas` import with `polars`
  - Update CSV reading and DataFrame operations to use `polars` syntax

* **coralnet_toolbox/IO/QtExportViscoreAnnotations.py**
  - Replace `pandas` import with `polars`
  - Update DataFrame creation and CSV export methods

* **coralnet_toolbox/MachineLearning/ExportDataset/QtClassify.py**
  - Replace `pandas` import with `polars`
  - Update DataFrame creation and CSV export methods

