### PR TITLE
Add save project shortcut

### DIFF
--- a/coralnet_toolbox/QtEventFilter.py
+++ b/coralnet_toolbox/QtEventFilter.py
@@ -83,6 +83,11 @@ class GlobalEventFilter(QObject):
                     self.image_window.cycle_next_image()
                     return True
 
+                # Handle Ctrl + Shift + S for saving project
+                if event.key() == Qt.Key_S and event.modifiers() == (Qt.ControlModifier | Qt.ShiftModifier):
+                    self.main_window.save_project_as()
+                    return True
+
             # Select all annotations on < key press with Shift+Ctrl
             if event.key() == Qt.Key_Less and event.modifiers() == (Qt.ShiftModifier | Qt.ControlModifier):
                 if self.main_window.select_tool_action.isChecked():

--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -1209,6 +1209,12 @@ class MainWindow(QMainWindow):
         except Exception as e:
             QMessageBox.critical(self, "Critical Error", f"{e}")
         
+    def save_project_as(self):
+        if self.current_project_path == "":
+            self.open_save_project_dialog()
+        else:
+            self.save_project_dialog.save_project_data(self.current_project_path)
+
     # TODO update IO classes to have dialogs
     def open_import_frames_dialog(self):
         try:


### PR DESCRIPTION
Add functionality to save project with Ctrl + Shift + S key combination.

* Add `save_project_as` method in `coralnet_toolbox/QtMainWindow.py` to handle saving the project.
  - Call `open_save_project_dialog` if `current_project_path` is empty.
  - Call `save_project_data` with `current_project_path` if not empty.

* Modify `coralnet_toolbox/QtEventFilter.py` to handle Ctrl + Shift + S key combination.
  - Call `main_window.save_project_as()` when the key combination is pressed.

