### PR TITLE
Update the to_dict() method for PolygonAnnotation and RectangleAnnotation to include the area and perimeter

### DIFF
--- a/coralnet_toolbox/Annotations/QtPolygonAnnotation.py
+++ b/coralnet_toolbox/Annotations/QtPolygonAnnotation.py
@@ -397,6 +397,8 @@ class PolygonAnnotation(Annotation):
         base_dict = super().to_dict()
         base_dict.update({
             'points': [(point.x(), point.y()) for point in self.points],
+            'area': self.calculate_area(),
+            'perimeter': self.calculate_perimeter()
         })
         return base_dict
 

--- a/coralnet_toolbox/Annotations/QtRectangleAnnotation.py
+++ b/coralnet_toolbox/Annotations/QtRectangleAnnotation.py
@@ -236,6 +236,8 @@ class RectangleAnnotation(Annotation):
         base_dict.update({
             'top_left': (self.top_left.x(), self.top_left.y()),
             'bottom_right': (self.bottom_right.x(), self.bottom_right.y()),
+            'area': self.calculate_area(),
+            'perimeter': self.calculate_perimeter()
         })
         return base_dict
 


### PR DESCRIPTION
Update the `to_dict()` method for `PolygonAnnotation` and `RectangleAnnotation` to include area and perimeter.

* Update `to_dict()` method in `coralnet_toolbox/Annotations/QtPolygonAnnotation.py` to include `area` and `perimeter` using `calculate_area()` and `calculate_perimeter()` methods.
* Update `to_dict()` method in `coralnet_toolbox/Annotations/QtRectangleAnnotation.py` to include `area` and `perimeter` using `calculate_area()` and `calculate_perimeter()` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jordan-Pierce/CoralNet-Toolbox/pull/147?shareId=9dc15dc9-93ad-44f5-907b-bef81b4d8bc1).