### PR TITLE
Update annotation graphics to show transparency fill and dotted line

### DIFF
--- a/coralnet_toolbox/Annotations/QtPatchAnnotation.py
+++ b/coralnet_toolbox/Annotations/QtPatchAnnotation.py
@@ -114,13 +114,14 @@ class PatchAnnotation(Annotation):
             color.setAlpha(self.transparency)
 
             if self.is_selected:
-                inverse_color = QColor(255 - color.red(), 255 - color.green(), 255 - color.blue())
-                pen = QPen(inverse_color, 6, Qt.DotLine)
+                pen = QPen(color, 6, Qt.DotLine)  # Use label color and dotted line
+                brush = QBrush(color)
+                brush.setStyle(Qt.SolidPattern)  # Ensure transparency fill is set to 100%
             else:
                 pen = QPen(color, 4, Qt.SolidLine)
+                brush = QBrush(color)
 
             self.graphics_item.setPen(pen)
-            brush = QBrush(color)
             self.graphics_item.setBrush(brush)
             self.graphics_item.update()
 

--- a/coralnet_toolbox/Annotations/QtPolygonAnnotation.py
+++ b/coralnet_toolbox/Annotations/QtPolygonAnnotation.py
@@ -271,13 +271,14 @@ class PolygonAnnotation(Annotation):
             color.setAlpha(self.transparency)
 
             if self.is_selected:
-                inverse_color = QColor(255 - color.red(), 255 - color.green(), 255 - color.blue())
-                pen = QPen(inverse_color, 6, Qt.DotLine)
+                pen = QPen(color, 6, Qt.DotLine)  # Use label color and dotted line
+                brush = QBrush(color)
+                brush.setStyle(Qt.SolidPattern)  # Ensure transparency fill is set to 100%
             else:
                 pen = QPen(color, 4, Qt.SolidLine)
+                brush = QBrush(color)
 
             self.graphics_item.setPen(pen)
-            brush = QBrush(color)
             self.graphics_item.setBrush(brush)
 
             if scene:

--- a/coralnet_toolbox/Annotations/QtRectangleAnnotation.py
+++ b/coralnet_toolbox/Annotations/QtRectangleAnnotation.py
@@ -142,13 +142,14 @@ class RectangleAnnotation(Annotation):
             color.setAlpha(self.transparency)
 
             if self.is_selected:
-                inverse_color = QColor(255 - color.red(), 255 - color.green(), 255 - color.blue())
-                pen = QPen(inverse_color, 6, Qt.DotLine)
+                pen = QPen(color, 6, Qt.DotLine)  # Use label color and dotted line
+                brush = QBrush(color)
+                brush.setStyle(Qt.SolidPattern)  # Ensure transparency fill is set to 100%
             else:
                 pen = QPen(color, 4, Qt.SolidLine)
+                brush = QBrush(color)
 
             self.graphics_item.setPen(pen)
-            brush = QBrush(color)
             self.graphics_item.setBrush(brush)
 
             if scene:


### PR DESCRIPTION
Update the graphic update for each Annotation type (Patch, Rectangle, and Polygon) to show transparency fill (100%) and a dotted line with the color of the label when selected.

* **QtPatchAnnotation.py**
  - Update the `update_graphics_item` method to use the label color and a dotted line when the annotation is selected.
  - Ensure the transparency fill is set to 100% when the annotation is selected.

* **QtRectangleAnnotation.py**
  - Update the `update_graphics_item` method to use the label color and a dotted line when the annotation is selected.
  - Ensure the transparency fill is set to 100% when the annotation is selected.

* **QtPolygonAnnotation.py**
  - Update the `update_graphics_item` method to use the label color and a dotted line when the annotation is selected.
  - Ensure the transparency fill is set to 100% when the annotation is selected.

