### PR TITLE
Replace QRangeSlider with two QSlider objects

### DIFF
--- a/coralnet_toolbox/AutoDistill/QtDeployModel.py
+++ b/coralnet_toolbox/AutoDistill/QtDeployModel.py
@@ -8,7 +8,6 @@ import torch
 from torch.cuda import empty_cache
 from autodistill.detection import CaptionOntology
 
-from superqt import QRangeSlider
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QApplication, QComboBox, QDialog,
                              QFormLayout, QHBoxLayout, QLabel, QLineEdit,
@@ -182,14 +181,21 @@ class DeployModelDialog(QDialog):
         min_val, max_val = self.main_window.get_area_thresh()
         self.area_thresh_min = int(min_val * 100)
         self.area_thresh_max = int(max_val * 100)
-        self.area_threshold_slider = QRangeSlider(Qt.Horizontal)
-        self.area_threshold_slider.setRange(0, 100)
-        self.area_threshold_slider.setValue((self.area_thresh_min, self.area_thresh_max))
-        self.area_threshold_slider.setTickPosition(QSlider.TicksBelow)
-        self.area_threshold_slider.setTickInterval(10)
-        self.area_threshold_slider.valueChanged.connect(self.update_area_label)
+        self.area_threshold_min_slider = QSlider(Qt.Horizontal)
+        self.area_threshold_min_slider.setRange(0, 100)
+        self.area_threshold_min_slider.setValue(self.area_thresh_min)
+        self.area_threshold_min_slider.setTickPosition(QSlider.TicksBelow)
+        self.area_threshold_min_slider.setTickInterval(10)
+        self.area_threshold_min_slider.valueChanged.connect(self.update_area_label)
+        self.area_threshold_max_slider = QSlider(Qt.Horizontal)
+        self.area_threshold_max_slider.setRange(0, 100)
+        self.area_threshold_max_slider.setValue(self.area_thresh_max)
+        self.area_threshold_max_slider.setTickPosition(QSlider.TicksBelow)
+        self.area_threshold_max_slider.setTickInterval(10)
+        self.area_threshold_max_slider.valueChanged.connect(self.update_area_label)
         self.area_threshold_label = QLabel(f"{self.area_thresh_min:.2f} - {self.area_thresh_max:.2f}")
-        layout.addRow("Area Threshold", self.area_threshold_slider)
+        layout.addRow("Area Threshold Min", self.area_threshold_min_slider)
+        layout.addRow("Area Threshold Max", self.area_threshold_max_slider)
         layout.addRow("", self.area_threshold_label)
 
         # SAM dropdown
@@ -247,7 +253,8 @@ class DeployModelDialog(QDialog):
     def initialize_area_threshold(self):
         """Initialize the area threshold range slider"""
         current_min, current_max = self.main_window.get_area_thresh()
-        self.area_threshold_slider.setValue((int(current_min * 100), int(current_max * 100)))
+        self.area_threshold_min_slider.setValue(int(current_min * 100))
+        self.area_threshold_max_slider.setValue(int(current_max * 100))
         self.area_thresh_min = current_min
         self.area_thresh_max = current_max
 
@@ -267,7 +274,11 @@ class DeployModelDialog(QDialog):
 
     def update_area_label(self):
         """Handle changes to area threshold range slider"""
-        min_val, max_val = self.area_threshold_slider.value()  # Returns tuple of values
+        min_val = self.area_threshold_min_slider.value()
+        max_val = self.area_threshold_max_slider.value()
+        if min_val > max_val:
+            min_val = max_val
+            self.area_threshold_min_slider.setValue(min_val)
         self.area_thresh_min = min_val / 100.0
         self.area_thresh_max = max_val / 100.0
         self.main_window.update_area_thresh(self.area_thresh_min, self.area_thresh_max)

--- a/coralnet_toolbox/BreakTime/QtSnake.py
+++ b/coralnet_toolbox/BreakTime/QtSnake.py
@@ -297,8 +297,8 @@ class SnakeGame(QMainWindow):
         Set up the user interface dimensions and appearance.
         """
         # Calculate dimensions and disable resizing/minimization.
-        width = self.column * self.size
-        height = self.row * self.size
+        width = int(self.column * self.size * 1.05)
+        height = int(self.row * self.size * 1.05)
         self.resize(width, height)
         self.setFixedSize(width, height)  # Prevent resizing/minimization.
         self.setWindowTitle(self.title)

--- a/coralnet_toolbox/IO/QtImportFrames.py
+++ b/coralnet_toolbox/IO/QtImportFrames.py
@@ -182,8 +182,8 @@ class ImportFrames(QDialog):
         self.every_n_frames_spinbox.valueChanged.connect(self.update_calculated_frames)
 
         range_layout.addRow("Sample Every N Frames:", self.every_n_frames_spinbox)
-        range_layout.addRow("Select Frame Range:", self.range_start_slider)
-        range_layout.addRow("Select Frame Range:", self.range_end_slider)
+        range_layout.addRow("Select Start Frame:", self.range_start_slider)
+        range_layout.addRow("Select End Frame:", self.range_end_slider)
         range_layout.addRow("", range_input_layout)
         range_layout.addRow("", self.time_range_label)
         range_tab.setLayout(range_layout)

--- a/coralnet_toolbox/IO/QtImportFrames.py
+++ b/coralnet_toolbox/IO/QtImportFrames.py
@@ -6,7 +6,6 @@ import os
 
 import cv2
 
-from superqt import QRangeSlider
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImage, QPixmap
 from PyQt5.QtWidgets import (QFileDialog, QVBoxLayout, QPushButton, QLabel, QLineEdit,
@@ -144,13 +143,19 @@ class ImportFrames(QDialog):
         self.time_range_label = QLabel("Time Range: No video loaded")
 
         # Range slider for selecting frames
-        self.range_slider = QRangeSlider(Qt.Horizontal)
-        self.range_slider.setEnabled(False)
-        self.range_slider.setValue((0, 0))
-        self.range_slider.setTickPosition(QSlider.TicksBelow)
-        self.range_slider.setTickInterval(10)
-        self.range_slider.valueChanged.connect(self.update_range_slider_label)
-        self.range_slider.valueChanged.connect(self.update_calculated_frames)
+        self.range_start_slider = QSlider(Qt.Horizontal)
+        self.range_start_slider.setEnabled(False)
+        self.range_start_slider.setTickPosition(QSlider.TicksBelow)
+        self.range_start_slider.setTickInterval(10)
+        self.range_start_slider.valueChanged.connect(self.update_range_slider_label)
+        self.range_start_slider.valueChanged.connect(self.update_calculated_frames)
+
+        self.range_end_slider = QSlider(Qt.Horizontal)
+        self.range_end_slider.setEnabled(False)
+        self.range_end_slider.setTickPosition(QSlider.TicksBelow)
+        self.range_end_slider.setTickInterval(10)
+        self.range_end_slider.valueChanged.connect(self.update_range_slider_label)
+        self.range_end_slider.valueChanged.connect(self.update_calculated_frames)
 
         # Create range input layout using spinboxes instead of line edits
         range_input_layout = QHBoxLayout()
@@ -177,7 +182,8 @@ class ImportFrames(QDialog):
         self.every_n_frames_spinbox.valueChanged.connect(self.update_calculated_frames)
 
         range_layout.addRow("Sample Every N Frames:", self.every_n_frames_spinbox)
-        range_layout.addRow("Select Frame Range:", self.range_slider)
+        range_layout.addRow("Select Frame Range:", self.range_start_slider)
+        range_layout.addRow("Select Frame Range:", self.range_end_slider)
         range_layout.addRow("", range_input_layout)
         range_layout.addRow("", self.time_range_label)
         range_tab.setLayout(range_layout)
@@ -438,7 +444,8 @@ class ImportFrames(QDialog):
 
     def update_range_slider_label(self):
         """Update the range spinboxes with current values."""
-        start, end = self.range_slider.value()
+        start = self.range_start_slider.value()
+        end = self.range_end_slider.value()
         self.range_start_spinbox.setValue(start)
         self.range_end_spinbox.setValue(end)
         self.update_time_label()
@@ -452,7 +459,8 @@ class ImportFrames(QDialog):
                 self.fps = cap.get(cv2.CAP_PROP_FPS)
 
                 # Enable the slider and set its range
-                self.range_slider.setEnabled(True)
+                self.range_start_slider.setEnabled(True)
+                self.range_end_slider.setEnabled(True)
                 self.range_start_spinbox.setEnabled(True)
                 self.range_end_spinbox.setEnabled(True)
 
@@ -462,9 +470,12 @@ class ImportFrames(QDialog):
                 self.frame_number_spinbox.setRange(0, total_frames - 1)
 
                 tick_interval = max(1, total_frames // 10)
-                self.range_slider.setRange(0, total_frames)
-                self.range_slider.setTickInterval(tick_interval)
-                self.range_slider.setValue((0, total_frames))
+                self.range_start_slider.setRange(0, total_frames)
+                self.range_end_slider.setRange(0, total_frames)
+                self.range_start_slider.setTickInterval(tick_interval)
+                self.range_end_slider.setTickInterval(tick_interval)
+                self.range_start_slider.setValue(0)
+                self.range_end_slider.setValue(total_frames)
 
                 # Update the spinbox values
                 self.range_start_spinbox.setValue(0)
@@ -478,8 +489,10 @@ class ImportFrames(QDialog):
             except Exception as e:
                 # Handle potential errors
                 print(f"Error reading video file: {e}")
-                self.range_slider.setValue((0, 0))
-                self.range_slider.setEnabled(False)
+                self.range_start_slider.setValue(0)
+                self.range_end_slider.setValue(0)
+                self.range_start_slider.setEnabled(False)
+                self.range_end_slider.setEnabled(False)
                 self.range_start_spinbox.setEnabled(False)
                 self.range_end_spinbox.setEnabled(False)
                 self.range_start_spinbox.setValue(0)
@@ -489,7 +502,7 @@ class ImportFrames(QDialog):
 
     def range_spinbox_changed(self):
         """Handle manual frame range spinbox changes"""
-        if not self.range_slider.isEnabled():
+        if not self.range_start_slider.isEnabled() or not self.range_end_slider.isEnabled():
             return
 
         # Get current values
@@ -506,12 +519,14 @@ class ImportFrames(QDialog):
                 self.range_end_spinbox.setValue(end)
 
         # Update the slider with new values
-        self.range_slider.setValue((start, end))
+        self.range_start_slider.setValue(start)
+        self.range_end_slider.setValue(end)
 
     def update_time_label(self):
         """Update the time range label based on fps and selected range."""
         try:
-            start, end = self.range_slider.value()
+            start = self.range_start_slider.value()
+            end = self.range_end_slider.value()
             start_time = start / self.fps
             end_time = end / self.fps
 
@@ -531,9 +546,10 @@ class ImportFrames(QDialog):
             frame_count = 0
 
             if self.current_tab == "range":
-                if self.range_slider.isEnabled():
+                if self.range_start_slider.isEnabled() and self.range_end_slider.isEnabled():
                     # Get range slider frames
-                    start, end = self.range_slider.value()
+                    start = self.range_start_slider.value()
+                    end = self.range_end_slider.value()
                     every_n = self.every_n_frames_spinbox.value()
                     frame_count = len(range(start, end, every_n))
             else:  # specific frames tab
@@ -583,7 +599,8 @@ class ImportFrames(QDialog):
         # Get the frame extension, and other values
         self.ext = self.frame_ext_combo.currentText().replace(".", "").lower()
         self.every_n_frames = self.every_n_frames_spinbox.value()
-        self.start_frame, self.end_frame = self.range_slider.value()
+        self.start_frame = self.range_start_slider.value()
+        self.end_frame = self.range_end_slider.value()
 
         if not self.video_file or not self.output_dir:
             QMessageBox.warning(self,

--- a/coralnet_toolbox/MachineLearning/BatchInference/QtBase.py
+++ b/coralnet_toolbox/MachineLearning/BatchInference/QtBase.py
@@ -57,8 +57,8 @@ class Base(QDialog):
         layout = QVBoxLayout()
         
         # Create a QLabel with explanatory text and hyperlink
-        info_label = QLabel("Perform batch inferencing on the selected images.\n \
-                             It is highly recommended to save the current project before proceeding.")
+        info_label = QLabel("Perform batch inferencing on the selected images. It is highly "
+                            "recommended to save the current project before proceeding.")
         
         info_label.setOpenExternalLinks(True)
         info_label.setWordWrap(True)

--- a/coralnet_toolbox/MachineLearning/DeployModel/QtBase.py
+++ b/coralnet_toolbox/MachineLearning/DeployModel/QtBase.py
@@ -167,7 +167,8 @@ class Base(QDialog):
     def initialize_area_threshold(self):
         """Initialize the area threshold range slider"""
         current_min, current_max = self.main_window.get_area_thresh()
-        self.area_threshold_slider.setValue((int(current_min * 100), int(current_max * 100)))
+        self.area_threshold_min_slider.setValue(int(current_min * 100))
+        self.area_threshold_max_slider.setValue(int(current_max * 100))
         self.area_thresh_min = current_min
         self.area_thresh_max = current_max
 
@@ -187,7 +188,11 @@ class Base(QDialog):
 
     def update_area_label(self):
         """Handle changes to area threshold range slider"""
-        min_val, max_val = self.area_threshold_slider.value()  # Returns tuple of values
+        min_val = self.area_threshold_min_slider.value()
+        max_val = self.area_threshold_max_slider.value()
+        if min_val > max_val:
+            min_val = max_val
+            self.area_threshold_min_slider.setValue(min_val)
         self.area_thresh_min = min_val / 100.0
         self.area_thresh_max = max_val / 100.0
         self.main_window.update_area_thresh(self.area_thresh_min, self.area_thresh_max)

--- a/coralnet_toolbox/MachineLearning/DeployModel/QtDetect.py
+++ b/coralnet_toolbox/MachineLearning/DeployModel/QtDetect.py
@@ -7,7 +7,6 @@ import os
 
 import numpy as np
 
-from superqt import QRangeSlider
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QApplication, QMessageBox, QLabel, QGroupBox, QFormLayout,
                              QComboBox, QSlider)
@@ -81,14 +80,21 @@ class Detect(Base):
         min_val, max_val = self.main_window.get_area_thresh()
         self.area_thresh_min = int(min_val * 100)
         self.area_thresh_max = int(max_val * 100)
-        self.area_threshold_slider = QRangeSlider(Qt.Horizontal)
-        self.area_threshold_slider.setRange(0, 100)
-        self.area_threshold_slider.setValue((self.area_thresh_min, self.area_thresh_max))
-        self.area_threshold_slider.setTickPosition(QSlider.TicksBelow)
-        self.area_threshold_slider.setTickInterval(10)
-        self.area_threshold_slider.valueChanged.connect(self.update_area_label)
+        self.area_threshold_min_slider = QSlider(Qt.Horizontal)
+        self.area_threshold_min_slider.setRange(0, 100)
+        self.area_threshold_min_slider.setValue(self.area_thresh_min)
+        self.area_threshold_min_slider.setTickPosition(QSlider.TicksBelow)
+        self.area_threshold_min_slider.setTickInterval(10)
+        self.area_threshold_min_slider.valueChanged.connect(self.update_area_label)
+        self.area_threshold_max_slider = QSlider(Qt.Horizontal)
+        self.area_threshold_max_slider.setRange(0, 100)
+        self.area_threshold_max_slider.setValue(self.area_thresh_max)
+        self.area_threshold_max_slider.setTickPosition(QSlider.TicksBelow)
+        self.area_threshold_max_slider.setTickInterval(10)
+        self.area_threshold_max_slider.valueChanged.connect(self.update_area_label)
         self.area_threshold_label = QLabel(f"{self.area_thresh_min:.2f} - {self.area_thresh_max:.2f}")
-        layout.addRow("Area Threshold", self.area_threshold_slider)
+        layout.addRow("Area Threshold Min", self.area_threshold_min_slider)
+        layout.addRow("Area Threshold Max", self.area_threshold_max_slider)
         layout.addRow("", self.area_threshold_label)
 
         # SAM dropdown

--- a/coralnet_toolbox/MachineLearning/DeployModel/QtSegment.py
+++ b/coralnet_toolbox/MachineLearning/DeployModel/QtSegment.py
@@ -7,7 +7,6 @@ import os
 
 import numpy as np
 
-from superqt import QRangeSlider
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QApplication, QMessageBox, QLabel, QGroupBox, QFormLayout,
                              QComboBox, QSlider)
@@ -81,14 +80,21 @@ class Segment(Base):
         min_val, max_val = self.main_window.get_area_thresh()
         self.area_thresh_min = int(min_val * 100)
         self.area_thresh_max = int(max_val * 100)
-        self.area_threshold_slider = QRangeSlider(Qt.Horizontal)
-        self.area_threshold_slider.setRange(0, 100)
-        self.area_threshold_slider.setValue((self.area_thresh_min, self.area_thresh_max))
-        self.area_threshold_slider.setTickPosition(QSlider.TicksBelow)
-        self.area_threshold_slider.setTickInterval(10)
-        self.area_threshold_slider.valueChanged.connect(self.update_area_label)
+        self.area_threshold_min_slider = QSlider(Qt.Horizontal)
+        self.area_threshold_min_slider.setRange(0, 100)
+        self.area_threshold_min_slider.setValue(self.area_thresh_min)
+        self.area_threshold_min_slider.setTickPosition(QSlider.TicksBelow)
+        self.area_threshold_min_slider.setTickInterval(10)
+        self.area_threshold_min_slider.valueChanged.connect(self.update_area_label)
+        self.area_threshold_max_slider = QSlider(Qt.Horizontal)
+        self.area_threshold_max_slider.setRange(0, 100)
+        self.area_threshold_max_slider.setValue(self.area_thresh_max)
+        self.area_threshold_max_slider.setTickPosition(QSlider.TicksBelow)
+        self.area_threshold_max_slider.setTickInterval(10)
+        self.area_threshold_max_slider.valueChanged.connect(self.update_area_label)
         self.area_threshold_label = QLabel(f"{self.area_thresh_min:.2f} - {self.area_thresh_max:.2f}")
-        layout.addRow("Area Threshold", self.area_threshold_slider)
+        layout.addRow("Area Threshold Min", self.area_threshold_min_slider)
+        layout.addRow("Area Threshold Max", self.area_threshold_max_slider)
         layout.addRow("", self.area_threshold_label)
 
         # SAM dropdown

--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -5,10 +5,8 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 import os
 import re
 import requests
-from packaging import version
 
 
-from superqt import QRangeSlider
 from PyQt5.QtCore import Qt, pyqtSignal, QEvent, QSize, QPoint
 from PyQt5.QtGui import QIcon, QMouseEvent
 from PyQt5.QtWidgets import (QListWidget, QCheckBox, QFrame, QComboBox)
@@ -811,16 +809,24 @@ class MainWindow(QMainWindow):
         # Area threshold controls
         min_val = self.area_thresh_min
         max_val = self.area_thresh_max
-        self.area_threshold_slider = QRangeSlider(Qt.Horizontal)
-        self.area_threshold_slider.setMinimum(0)
-        self.area_threshold_slider.setMaximum(100)
-        self.area_threshold_slider.setTickPosition(QSlider.TicksBelow)
-        self.area_threshold_slider.setTickInterval(10)
-        self.area_threshold_slider.setValue((int(min_val * 100), int(max_val * 100)))
+        self.area_threshold_min_slider = QSlider(Qt.Horizontal)
+        self.area_threshold_min_slider.setMinimum(0)
+        self.area_threshold_min_slider.setMaximum(100)
+        self.area_threshold_min_slider.setTickPosition(QSlider.TicksBelow)
+        self.area_threshold_min_slider.setTickInterval(10)
+        self.area_threshold_min_slider.setValue(int(min_val * 100))
+        self.area_threshold_min_slider.valueChanged.connect(self.update_area_label)
+        self.area_threshold_max_slider = QSlider(Qt.Horizontal)
+        self.area_threshold_max_slider.setMinimum(0)
+        self.area_threshold_max_slider.setMaximum(100)
+        self.area_threshold_max_slider.setTickPosition(QSlider.TicksBelow)
+        self.area_threshold_max_slider.setTickInterval(10)
+        self.area_threshold_max_slider.setValue(int(max_val * 100))
+        self.area_threshold_max_slider.valueChanged.connect(self.update_area_label)
         self.area_threshold_label = QLabel(f"{min_val:.2f} - {max_val:.2f}")
-        self.area_threshold_slider.valueChanged.connect(self.update_area_label)
         area_thresh_layout = QVBoxLayout()
-        area_thresh_layout.addWidget(self.area_threshold_slider)
+        area_thresh_layout.addWidget(self.area_threshold_min_slider)
+        area_thresh_layout.addWidget(self.area_threshold_max_slider)
         area_thresh_layout.addWidget(self.area_threshold_label)
         area_thresh_widget = QWidget()
         area_thresh_widget.setLayout(area_thresh_layout)
@@ -1192,12 +1198,17 @@ class MainWindow(QMainWindow):
         if self.area_thresh_min != min_val or self.area_thresh_max != max_val:
             self.area_thresh_min = min_val
             self.area_thresh_max = max_val
-            self.area_threshold_slider.setValue((int(min_val * 100), int(max_val * 100)))
+            self.area_threshold_min_slider.setValue(int(min_val * 100))
+            self.area_threshold_max_slider.setValue(int(max_val * 100))
             self.areaChanged.emit(min_val, max_val)
 
-    def update_area_label(self, value):
+    def update_area_label(self):
         """Handle changes to area threshold range slider"""
-        min_val, max_val = self.area_threshold_slider.value()  # Returns tuple of values
+        min_val = self.area_threshold_min_slider.value()
+        max_val = self.area_threshold_max_slider.value()
+        if min_val > max_val:
+            min_val = max_val
+            self.area_threshold_min_slider.setValue(min_val)
         self.area_thresh_min = min_val / 100.0
         self.area_thresh_max = max_val / 100.0
         self.area_threshold_label.setText(f"{self.area_thresh_min:.2f} - {self.area_thresh_max:.2f}")

--- a/coralnet_toolbox/main.py
+++ b/coralnet_toolbox/main.py
@@ -60,6 +60,8 @@ def run():
         error_dialog.setWindowTitle("Unexpected Error")
         error_dialog.setText("An unexpected error has occurred.")
         error_dialog.setDetailedText(error_message)
+        # Resize the error_dialog to fit the detailed text
+        error_dialog.resize(400, 300)
         
         # Only attempt to use main_window if it exists and is a valid object
         if main_window is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 PyQt5>=5.15.11
-superqt>=0.7.1
 pyqtdarktheme
 ultralytics==8.3.0
 supervision>=0.24.0


### PR DESCRIPTION
Replace all instances of `superqt.QRangeSlider` with two `QSlider` objects for min and max values.

* **coralnet_toolbox/AutoDistill/QtDeployModel.py**
  - Replace `QRangeSlider` with two `QSlider` objects for area threshold controls.
  - Ensure min `QSlider` handle cannot exceed max `QSlider` handle.
  - Update `setup_parameters_layout` method to initialize and configure the two `QSlider` objects.

* **coralnet_toolbox/IO/QtImportFrames.py**
  - Replace `QRangeSlider` with two `QSlider` objects for selecting frames.
  - Ensure min `QSlider` handle cannot exceed max `QSlider` handle.
  - Update `create_sample_group` method to initialize and configure the two `QSlider` objects.

* **coralnet_toolbox/MachineLearning/DeployModel/QtDetect.py**
  - Replace `QRangeSlider` with two `QSlider` objects for area threshold controls.
  - Ensure min `QSlider` handle cannot exceed max `QSlider` handle.
  - Update `setup_parameters_layout` method to initialize and configure the two `QSlider` objects.

* **coralnet_toolbox/QtMainWindow.py**
  - Replace `QRangeSlider` with two `QSlider` objects for area threshold controls.
  - Ensure min `QSlider` handle cannot exceed max `QSlider` handle.
  - Update `setup_parameters_layout` method to initialize and configure the two `QSlider` objects.

