### PR TITLE
169

### DIFF
--- a/coralnet_toolbox/Annotations/QtPolygonAnnotation.py
+++ b/coralnet_toolbox/Annotations/QtPolygonAnnotation.py
@@ -116,7 +116,11 @@ class PolygonAnnotation(Annotation):
         n = len(self.points)
         for i in range(n):
             j = (i + 1) % n
-            perimeter += self.points[i].distanceToPoint(self.points[j])
+            # Calculate Euclidean distance between points manually
+            dx = self.points[i].x() - self.points[j].x()
+            dy = self.points[i].y() - self.points[j].y()
+            distance = math.sqrt(dx * dx + dy * dy)
+            perimeter += distance
         return perimeter
 
     def get_polygon(self):

--- a/coralnet_toolbox/__init__.py
+++ b/coralnet_toolbox/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for CoralNet-Toolbox."""
 
-__version__ = "0.0.41"
+__version__ = "0.0.42"
 __author__ = "Jordan Pierce"
 __email__ = "jordan.pierce@noaa.gov"
 __credits__ = "National Center for Coastal and Ocean Sciences (NCCOS)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coralnet-toolbox"
-version = "0.0.41"
+version = "0.0.42"
 dynamic = [
     "dependencies",
 ]
@@ -43,7 +43,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.0.41"
+current_version = "0.0.42"
 commit = true
 tag = true
 


### PR DESCRIPTION
This pull request includes updates to the `get_perimeter` method in `QtPolygonAnnotation.py` to improve clarity and precision, along with a version bump for the `coralnet-toolbox` package from 0.0.41 to 0.0.42.

### Code improvement:

* [`coralnet_toolbox/Annotations/QtPolygonAnnotation.py`](diffhunk://#diff-3858fb2b7dbdef820fad647950b75fe68bb91e2d3e91ad5e640b7b4a0029cd26L119-R123): Replaced the `distanceToPoint` method with a manual calculation of Euclidean distance between points in the `get_perimeter` method for better control and clarity.

### Version update:

* [`coralnet_toolbox/__init__.py`](diffhunk://#diff-f0b913713d71f1e76222df635f3bc47af631b1ea81af9c318d131c51d831cdf2L3-R3): Updated the package version from 0.0.41 to 0.0.42.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the `version` and `current_version` fields to reflect the new version 0.0.42. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L46-R46)

Addresses #169 