### PR TITLE
V0.0.46

### DIFF
--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -985,6 +985,7 @@ class MainWindow(QMainWindow):
                 self.patch_tool_action.setChecked(False)
                 self.rectangle_tool_action.setChecked(False)
                 self.polygon_tool_action.setChecked(False)
+                self.see_anything_tool_action.setChecked(False)
         
                 self.toolChanged.emit("sam")
             else:

--- a/coralnet_toolbox/Tools/QtSeeAnythingTool.py
+++ b/coralnet_toolbox/Tools/QtSeeAnythingTool.py
@@ -101,11 +101,24 @@ class SeeAnythingTool(Tool):
         self.annotation_window.scene.update()  
 
     def get_workarea_thickness(self):
-        """Calculate appropriate line thickness based on current view dimensions."""
-        extent = self.annotation_window.viewportToScene()
-        view_width = round(extent.width())
-        view_height = round(extent.height())
-        return max(5, min(20, max(view_width, view_height) // 1000))
+        """
+        Calculate line thickness so it appears visually consistent regardless of zoom or image size.
+        """
+        view = self.annotation_window
+        if not view.pixmap_image:
+            return 7  # fallback
+
+        # Get the current zoom scale from the view's transformation matrix
+        # m11() is the horizontal scale factor (scene to view)
+        scale = view.transform().m11()
+        if scale == 0:
+            scale = 1  # avoid division by zero
+
+        desired_px = 7  # Desired thickness in screen pixels
+
+        # To keep the line visually consistent, divide by the scale
+        thickness = max(1, int(round(desired_px / scale)))
+        return thickness
 
     def set_working_area(self):
         """
@@ -177,7 +190,27 @@ class SeeAnythingTool(Tool):
 
         self.annotation_window.setCursor(Qt.CrossCursor)
         
-        self.annotation_window.scene.update()  
+        self.annotation_window.scene.update() 
+        
+    def get_rectangle_graphic_thickness(self):
+        """
+        Calculate line thickness so it appears visually consistent regardless of zoom or image size.
+        """
+        view = self.annotation_window
+        if not view.pixmap_image:
+            return 2  # fallback
+
+        # Get the current zoom scale from the view's transformation matrix
+        # m11() is the horizontal scale factor (scene to view)
+        scale = view.transform().m11()
+        if scale == 0:
+            scale = 1  # avoid division by zero
+
+        desired_px = 2  # Desired thickness in screen pixels
+
+        # To keep the line visually consistent, divide by the scale
+        thickness = max(1, int(round(desired_px / scale)))
+        return thickness 
         
     def create_rectangle_graphics(self):
         """
@@ -206,7 +239,7 @@ class SeeAnythingTool(Tool):
 
             # Style the rectangle
             pen = QPen(QColor(color))
-            pen.setWidth(2)
+            pen.setWidth(self.get_rectangle_graphic_thickness())
             pen.setStyle(Qt.DashLine)
             self.current_rect_graphics.setPen(pen)
 

--- a/coralnet_toolbox/__init__.py
+++ b/coralnet_toolbox/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for CoralNet-Toolbox."""
 
-__version__ = "0.0.45"
+__version__ = "0.0.46"
 __author__ = "Jordan Pierce"
 __email__ = "jordan.pierce@noaa.gov"
 __credits__ = "National Center for Coastal and Ocean Sciences (NCCOS)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coralnet-toolbox"
-version = "0.0.45"
+version = "0.0.46"
 dynamic = [
     "dependencies",
 ]
@@ -43,7 +43,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.0.45"
+current_version = "0.0.46"
 commit = true
 tag = true
 


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the CoralNet Toolbox, primarily focusing on improving graphic rendering consistency, refactoring methods for better maintainability, and updating the package version. The most significant changes include adding dynamic line thickness calculations, refactoring the `set_working_area` and `clear_prompt_graphics` methods, and updating the package version to `0.0.46`.

### Enhancements to graphic rendering:
* Introduced methods `get_workarea_thickness` and `get_rectangle_graphic_thickness` in `QtSAMTool.py` and `QtSeeAnythingTool.py` to ensure line thickness remains visually consistent regardless of zoom or image size. These replace hardcoded thickness values with dynamic calculations. [[1]](diffhunk://#diff-5dfe5386b33d0a75d1273827734bd594687fa52373ae110e0d80a84d2eb578ccR153-R293) [[2]](diffhunk://#diff-62099e50ff3daeb40190c1b989298cc1d463b6e20046deece117a199cb022d27L104-R121) [[3]](diffhunk://#diff-62099e50ff3daeb40190c1b989298cc1d463b6e20046deece117a199cb022d27R195-R214)

* Updated the `create_rectangle_graphics` method in `QtSeeAnythingTool.py` to use the new `get_rectangle_graphic_thickness` method for setting rectangle line thickness.

### Code refactoring:
* Refactored and reintroduced the `set_working_area` and `clear_prompt_graphics` methods in `QtSAMTool.py` with improved readability and maintainability. These methods were previously removed but have been added back with enhancements. [[1]](diffhunk://#diff-5dfe5386b33d0a75d1273827734bd594687fa52373ae110e0d80a84d2eb578ccR153-R293) [[2]](diffhunk://#diff-5dfe5386b33d0a75d1273827734bd594687fa52373ae110e0d80a84d2eb578ccL327-L427)

* Adjusted transparency behavior in the `create_annotation` method in `QtSAMTool.py` for better visual clarity during hover interactions.

### Package version update:
* Updated the package version from `0.0.45` to `0.0.46` in `__init__.py` and `pyproject.toml` to reflect the new changes. [[1]](diffhunk://#diff-f0b913713d71f1e76222df635f3bc47af631b1ea81af9c318d131c51d831cdf2L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L46-R46)