### PR TITLE
Clean up

### DIFF
--- a/coralnet_toolbox/Common/QtGraphicsUtility.py
+++ b/coralnet_toolbox/Common/QtGraphicsUtility.py
@@ -87,13 +87,13 @@ class GraphicsUtility:
             int: Appropriate handle size in pixels
         """
         if not hasattr(view, 'pixmap_image') or not view.pixmap_image:
-            return 20  # fallback size
+            return 10  # fallback size
             
         scale = view.transform().m11()
         if scale == 0:
             scale = 1  # avoid division by zero
             
-        desired_px = 20  # Desired handle size in screen pixels
+        desired_px = 10  # Desired handle size in screen pixels
         size = max(6, int(round(desired_px / scale)))
         return size
     

--- a/coralnet_toolbox/IO/QtImportImages.py
+++ b/coralnet_toolbox/IO/QtImportImages.py
@@ -78,11 +78,6 @@ class ImportImages:
                 # Update the progress bar
                 progress_bar.update_progress()
 
-            # If we have imported images, set the selected image path before filtering
-            # This prevents the automatic loading of the first image
-            if imported_paths:
-                self.image_window.selected_image_path = imported_paths[-1]
-                
             # Apply filtering to update the view
             self.image_window.filter_images()
             

--- a/coralnet_toolbox/IO/QtImportImages.py
+++ b/coralnet_toolbox/IO/QtImportImages.py
@@ -78,6 +78,11 @@ class ImportImages:
                 # Update the progress bar
                 progress_bar.update_progress()
 
+            # If we have imported images, set the selected image path before filtering
+            # This prevents the automatic loading of the first image
+            if imported_paths:
+                self.image_window.selected_image_path = imported_paths[-1]
+                
             # Apply filtering to update the view
             self.image_window.filter_images()
             

--- a/coralnet_toolbox/IO/QtOpenProject.py
+++ b/coralnet_toolbox/IO/QtOpenProject.py
@@ -178,6 +178,14 @@ class OpenProject(QDialog):
                 # Update the progress bar
                 progress_bar.update_progress()
 
+            # Set the selected image path to the last image *before* any filtering happens
+            # This prevents the automatic loading of the first image during filtering
+            if image_paths:
+                self.image_window.selected_image_path = image_paths[-1]
+                
+            # Apply any pending filtering
+            self.image_window.filter_images()
+            
             # Show the last image if any were imported
             if self.image_window.raster_manager.image_paths:
                 self.image_window.load_image_by_path(self.image_window.raster_manager.image_paths[-1])

--- a/coralnet_toolbox/IO/QtOpenProject.py
+++ b/coralnet_toolbox/IO/QtOpenProject.py
@@ -3,11 +3,12 @@ import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 import os
-import ujson as json
+import json
 
 from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (QDialog, QFileDialog, QVBoxLayout, QPushButton, QLabel,
-                             QMessageBox, QApplication, QGroupBox, QHBoxLayout, QFormLayout,
+                             QMessageBox, QApplication, QGroupBox, QHBoxLayout, QFormLayout, 
                              QLineEdit)
 
 from coralnet_toolbox.QtLabelWindow import Label
@@ -21,7 +22,7 @@ from coralnet_toolbox.QtProgressBar import ProgressBar
 
 
 # ----------------------------------------------------------------------------------------------------------------------
-# Classesf
+# Classes
 # ----------------------------------------------------------------------------------------------------------------------
 
 
@@ -34,7 +35,7 @@ class OpenProject(QDialog):
         self.annotation_window = main_window.annotation_window
 
         self.current_project_path = self.main_window.current_project_path
-
+        
         self.updated_paths = {}
 
         self.setWindowTitle("Open Project")
@@ -44,7 +45,7 @@ class OpenProject(QDialog):
         self.setup_open_layout()
         # Setup the buttons layout
         self.setup_buttons_layout()
-
+        
     def showEvent(self, event):
         super().showEvent(event)
         self.file_path_edit.setText(self.current_project_path)
@@ -54,71 +55,71 @@ class OpenProject(QDialog):
         layout = QVBoxLayout()
         group_box = QGroupBox("Open Project")
         form_layout = QFormLayout()
-
+        
         # Create horizontal layout for path and browse button
         path_layout = QHBoxLayout()
         self.file_path_edit = QLineEdit()
         self.file_path_edit.setReadOnly(True)
         path_layout.addWidget(self.file_path_edit)
-
+        
         # Add browse button
         self.browse_button = QPushButton("Browse")
         self.browse_button.clicked.connect(self.browse_file)
         path_layout.addWidget(self.browse_button)
-
+        
         # Add to form layout
         form_layout.addRow("Project File:", path_layout)
-
+        
         # Set group box layout
         group_box.setLayout(form_layout)
-
+        
         # Add group box to main layout
         layout.addWidget(group_box)
         self.setLayout(layout)
 
     def setup_buttons_layout(self):
         layout = self.layout()
-
+        
         # Create horizontal layout for buttons
         button_layout = QHBoxLayout()
-
+        
         # Add open button
         self.open_button = QPushButton("Open")
         self.open_button.clicked.connect(self.load_selected_project)
         button_layout.addWidget(self.open_button)
-
+        
         # Add cancel button
         self.cancel_button = QPushButton("Cancel")
         self.cancel_button.clicked.connect(self.reject)
         button_layout.addWidget(self.cancel_button)
-
+        
         layout.addLayout(button_layout)
 
     def browse_file(self):
         options = QFileDialog.Options()
-        file_path, _ = QFileDialog.getOpenFileName(self,
-                                                   "Open Project JSON",
-                                                   "",
-                                                   "JSON Files (*.json);;All Files (*)",
+        file_path, _ = QFileDialog.getOpenFileName(self, 
+                                                   "Open Project JSON", 
+                                                   "", 
+                                                   "JSON Files (*.json);;All Files (*)", 
                                                    options=options)
         if file_path:
             self.file_path_edit.setText(file_path)
-
+            
     def load_selected_project(self):
         file_path = self.file_path_edit.text()
         if file_path:
             self.load_project(file_path)
         else:
-            QMessageBox.warning(self,
-                                "Error",
+            QMessageBox.warning(self, 
+                                "Error", 
                                 "Please select a project file first.")
 
     def open_project(self):
         options = QFileDialog.Options()
-        file_path, _ = QFileDialog.getOpenFileName(self,
-                                                   "Open Project JSON",
-                                                   "",
-                                                   "JSON Files (*.json);;All Files (*)",
+        file_path, _ = QFileDialog.getOpenFileName(self, 
+                                                   "Open Project JSON", 
+                                                   "", 
+                                                   "JSON Files (*.json);;All Files (*)", 
                                                    options=options)
         if file_path:
             self.load_project(file_path)
@@ -139,29 +140,29 @@ class OpenProject(QDialog):
             # Update current project path
             self.current_project_path = file_path
 
-            QMessageBox.information(self.annotation_window,
+            QMessageBox.information(self.annotation_window, 
                                     "Project Loaded",
                                     "Project has been successfully loaded.")
 
         except Exception as e:
-            QMessageBox.warning(self.annotation_window,
-                                "Error Loading Project",
+            QMessageBox.warning(self.annotation_window, 
+                                "Error Loading Project", 
                                 f"An error occurred while loading the project: {str(e)}")
 
         finally:
             # Restore the cursor to the default cursor
             QApplication.restoreOverrideCursor()
-
+        
         # Exit
         self.accept()
 
     def import_images(self, image_paths):
         if not image_paths:
             return
-
+        
         if not all([os.path.exists(path) for path in image_paths]):
-            image_paths, self.updated_paths = UpdateImagePaths.update_paths(image_paths)
-
+            image_paths, self.updated_paths = QtUpdateImagePaths.update_paths(image_paths)
+        
         # Start progress bar
         total_images = len(image_paths)
         progress_bar = ProgressBar(self.image_window, title="Importing Images")
@@ -174,17 +175,9 @@ class OpenProject(QDialog):
                 # Use the improved add_image method which handles both
                 # adding to raster_manager and updating filtered_paths
                 self.image_window.add_image(path)
-
+                
                 # Update the progress bar
                 progress_bar.update_progress()
-
-            # Set the selected image path to the last image *before* any filtering happens
-            # This prevents the automatic loading of the first image during filtering
-            if image_paths:
-                self.image_window.selected_image_path = image_paths[-1]
-                
-            # Apply any pending filtering
-            self.image_window.filter_images()
             
             # Show the last image if any were imported
             if self.image_window.raster_manager.image_paths:
@@ -202,7 +195,7 @@ class OpenProject(QDialog):
     def import_labels(self, labels):
         if not labels:
             return
-
+        
         # Create a progress bar
         total_labels = len(labels)
         progress_bar = ProgressBar(self.annotation_window, "Importing Labels")
@@ -214,7 +207,7 @@ class OpenProject(QDialog):
             for label in labels:
                 # Create a new label object
                 label = Label.from_dict(label)
-
+                
                 # Create a new label if it doesn't already exist
                 self.label_window.add_label_if_not_exists(label.short_label_code,
                                                           label.long_label_code,
@@ -222,7 +215,7 @@ class OpenProject(QDialog):
                                                           label.id)
                 # Update the progress bar
                 progress_bar.update_progress()
-
+                
         except Exception as e:
             QMessageBox.warning(self.annotation_window,
                                 "Error Importing Labels",
@@ -236,7 +229,7 @@ class OpenProject(QDialog):
     def import_annotations(self, annotations):
         if not annotations:
             return
-
+        
         # Start the progress bar
         total_annotations = sum(len(image_annotations) for image_annotations in annotations.values())
         progress_bar = ProgressBar(self.annotation_window, title="Importing Annotations")
@@ -249,10 +242,10 @@ class OpenProject(QDialog):
         try:
             # Loop through the annotations
             for image_path, image_annotations in annotations.items():
-
+                
                 # Checking if the image path is updated (moved)
                 updated_path = False
-
+                
                 if image_path not in self.image_window.raster_manager.image_paths:
                     # Check if the path was updated
                     if image_path in self.updated_paths:
@@ -261,17 +254,17 @@ class OpenProject(QDialog):
                     else:
                         print(f"Warning: Image not found: {image_path}")
                         continue
-
+                
                 for annotation in image_annotations:
                     # Check if all required keys are present
                     if not all(key in annotation for key in keys):
                         print(f"Warning: Missing required keys in annotation: {annotation}")
                         continue
-
+                    
                     # Check if the image path was updated
                     if updated_path:
                         annotation['image_path'] = image_path
-
+                    
                     # Get the annotation type
                     annotation_type = annotation.get('type')
                     if annotation_type == 'PatchAnnotation':
@@ -285,10 +278,10 @@ class OpenProject(QDialog):
 
                     # Add annotation to the dict
                     self.annotation_window.add_annotation_to_dict(annotation)
-
+                    
                     # Update the progress bar
                     progress_bar.update_progress()
-
+                    
                 # Update the image window's image annotations
                 self.image_window.update_image_annotations(image_path)
 

--- a/coralnet_toolbox/Tools/QtWorkAreaTool.py
+++ b/coralnet_toolbox/Tools/QtWorkAreaTool.py
@@ -383,6 +383,9 @@ class WorkAreaTool(Tool):
         
     def on_image_loaded(self, width, height):
         """Handle when a new image is loaded."""
+        # Clear existing work areas first, regardless of whether tool is active
+        self.hide_work_area_graphics()
+        
         # Only reload work areas if this tool is currently active
         if self.annotation_window.selected_tool == "work_area":
             self.load_work_areas()

--- a/coralnet_toolbox/Tools/QtWorkAreaTool.py
+++ b/coralnet_toolbox/Tools/QtWorkAreaTool.py
@@ -308,7 +308,7 @@ class WorkAreaTool(Tool):
         rect = work_area.rect
         
         # Create a group item to hold the X shape
-        button_size = self.graphics_utility.get_handle_size(self.annotation_window)
+        button_size = self.graphics_utility.get_handle_size(self.annotation_window) * 2  # Size of the button
         button_group = QGraphicsItemGroup(work_area.graphics_item)
         
         # Create two diagonal lines to form an X

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyQt5>=5.15.11
 pyqtdarktheme
-ultralytics>=8.3.100
+ultralytics>=8.3.127
 open-clip-torch>=2.20.0
 supervision>=0.24.0
 scikit-learn
@@ -10,7 +10,7 @@ timm==0.9.2
 autodistill
 transformers>=4.5.0
 x-segment-anything>=0.0.8
-yolo-tiling>=0.0.17
+yolo-tiling>=0.0.18
 roboflow
 rasterio
 requests


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple files in the `coralnet_toolbox` project. Key updates include improvements to annotation combination logic, optimization of mask processing for memory efficiency, and UI adjustments for better usability. Below are the most significant changes:

### Annotation Combination Enhancements:
* Updated `combine` method in `QtPatchAnnotation` to handle both `PatchAnnotation` and `PolygonAnnotation`, allowing for more flexible combinations of annotation types. Added logic to separate patches and polygons, and to combine multiple polygons if necessary. [[1]](diffhunk://#diff-0b1879b10a96d14ed9bd081ec691da0a84d2819bbebb802897f2c142bf3aa036L235-R241) [[2]](diffhunk://#diff-0b1879b10a96d14ed9bd081ec691da0a84d2819bbebb802897f2c142bf3aa036R251-R263) [[3]](diffhunk://#diff-0b1879b10a96d14ed9bd081ec691da0a84d2819bbebb802897f2c142bf3aa036L274-R282) [[4]](diffhunk://#diff-0b1879b10a96d14ed9bd081ec691da0a84d2819bbebb802897f2c142bf3aa036L294-R302) [[5]](diffhunk://#diff-0b1879b10a96d14ed9bd081ec691da0a84d2819bbebb802897f2c142bf3aa036L308-R314) [[6]](diffhunk://#diff-0b1879b10a96d14ed9bd081ec691da0a84d2819bbebb802897f2c142bf3aa036L319-R342)
* Enhanced `combine_selected_annotations` method in `QtSelectTool` to support combining mixed annotation types (e.g., patches with polygons) while maintaining restrictions on incompatible types like rectangles. [[1]](diffhunk://#diff-0b208d723b5ce62b8b15ce7fe32c34ef96788fd77870f5b67d322a3009c1e3f4L529-L538) [[2]](diffhunk://#diff-0b208d723b5ce62b8b15ce7fe32c34ef96788fd77870f5b67d322a3009c1e3f4L557-R578)

### Performance Improvements:
* Optimized mask processing in `ResultsProcessor` by moving operations to the CPU to reduce GPU memory usage, using boolean tensors for efficiency, and adding garbage collection to free memory during processing.

### UI and Usability Adjustments:
* Adjusted handle size calculation in `QtGraphicsUtility` to use a smaller fallback size (`10px` instead of `20px`) for better visual consistency.
* Doubled the size of remove buttons in `QtWorkAreaTool` for improved visibility and usability.
* Ensured work areas are cleared when a new image is loaded, regardless of the active tool, to prevent visual clutter.

### Dependency and Code Cleanup:
* Replaced `ujson` with the standard `json` library in `QtOpenProject` for improved compatibility and maintainability.
* Fixed a minor typo in a comment within `QtOpenProject` for clarity.

These updates collectively improve the functionality, performance, and user experience of the toolbox.