### PR TITLE
updated work area keys and usage

### DIFF
--- a/coralnet_toolbox/Tile/TileDataset/QtBase.py
+++ b/coralnet_toolbox/Tile/TileDataset/QtBase.py
@@ -92,7 +92,6 @@ class Base(QDialog):
         self.tile_config_group.setTitle("Tile Configuration Parameters")
         layout = QFormLayout()
 
-        # Existing tile config code...
         self.tile_size_input = TileSizeInput()
         layout.addRow(self.tile_size_input)
 
@@ -138,7 +137,7 @@ class Base(QDialog):
         self.dataset_config_group.setTitle("Dataset Configuration Parameters")
         layout = QFormLayout()
 
-        # Image Extensions - Now in separate group box with vertical form layout
+        # Image Extensions 
         ext_group = QGroupBox("Image Extensions")
         ext_form = QFormLayout(ext_group)
         
@@ -150,12 +149,19 @@ class Base(QDialog):
         self.output_ext_combo.addItems([".png", ".tif", ".jpeg", ".jpg"])
         self.output_ext_combo.setEditable(True)
         
+        # Add compression spinbox
+        self.compression_spinbox = QSpinBox()
+        self.compression_spinbox.setRange(0, 100)
+        self.compression_spinbox.setValue(90)
+        self.compression_spinbox.setSingleStep(5)
+        
         ext_form.addRow("Input Extension:", self.input_ext_combo)
         ext_form.addRow("Output Extension:", self.output_ext_combo)
+        ext_form.addRow("Compression (0-100):", self.compression_spinbox)
         
         layout.addRow(ext_group)
 
-        # Train, Validation, and Test Ratios - Now in separate group box with vertical form layout
+        # Train, Validation, and Test Ratios 
         ratios_group = QGroupBox("Dataset Split Ratios")
         ratios_form = QFormLayout(ratios_group)
 
@@ -180,7 +186,7 @@ class Base(QDialog):
 
         layout.addRow(ratios_group)
 
-        # Advanced options - Now in separate group box with vertical form layout
+        # Advanced options 
         advanced_group = QGroupBox("Advanced Parameters")
         advanced_form = QFormLayout(advanced_group)
         
@@ -199,25 +205,31 @@ class Base(QDialog):
         
         layout.addRow(advanced_group)
         
+        # Misc. options
+        misc_group = QGroupBox("Misc.")
+        misc_form = QFormLayout(misc_group)
+        
         # Include negative samples
         self.include_negatives_combo = QComboBox()
         self.include_negatives_combo.addItems(["True", "False"])
         self.include_negatives_combo.setEditable(False)
         self.include_negatives_combo.setCurrentIndex(0)
-        layout.addRow("Include Negative Samples:", self.include_negatives_combo)
+        misc_form.addRow("Include Negative Samples:", self.include_negatives_combo)
         
         # Copy source data
         self.copy_source_data_combo = QComboBox()
         self.copy_source_data_combo.addItems(["True", "False"])
         self.copy_source_data_combo.setEditable(False)
         self.copy_source_data_combo.setCurrentIndex(1)
-        layout.addRow("Copy Source Data:", self.copy_source_data_combo)
+        misc_form.addRow("Copy Source Data:", self.copy_source_data_combo)
         
         # Number of Visualization Samples
         self.num_viz_sample_spinbox = QSpinBox()
         self.num_viz_sample_spinbox.setRange(1, 1000)
-        self.num_viz_sample_spinbox.setValue(5)
-        layout.addRow("# Visualization Samples:", self.num_viz_sample_spinbox)
+        self.num_viz_sample_spinbox.setValue(3)
+        misc_form.addRow("# Visualization Samples:", self.num_viz_sample_spinbox)
+        
+        layout.addRow(misc_group)
 
         self.dataset_config_group.setLayout(layout)
 
@@ -368,6 +380,7 @@ class Base(QDialog):
 
         input_ext = self.input_ext_combo.currentText()
         output_ext = self.output_ext_combo.currentText()
+        compression = self.compression_spinbox.value()
         densify_factor = self.densify_factor_spinbox.value()
         smoothing_tolerance = self.smoothing_tolerance_spinbox.value()
         train_ratio = self.train_ratio_spinbox.value()
@@ -431,6 +444,7 @@ class Base(QDialog):
             margins=margins,
             include_negative_samples=include_negatives,
             copy_source_data=copy_source_data,
+            compression=compression,
         )
 
         tiler = YoloTiler(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -160,13 +160,18 @@ The main window consists of several components:
   - **Left-Click**: Start a box; press again to end a box.
   - **Backspace**: Discard unfinalized predictions.
 
-- **Work Area Tool**: After a model is loaded
-  - **Space Bar**: Set working area on the cucrrent view;
-  - **Left-Click**: Start a work area; press again to end a work area;
-  - **Ctrl + Shift**: Show working area removal button (click the "X" to remove);
-  - **Ctrl + Shift + Backspace**: Remove all working areas in the current image;
-  - **Deploy a Model**:
-    - With working areas set, any model used will make predictions in just those areas.
+- **Work Area Tool**: For creating restricted areas for model prediction
+  - **Left-Click**: Start drawing a work area; click again to finish drawing.
+  - **Ctrl + Space**: Create a work area from the current view.
+  - **Ctrl + Shift**: Show removal buttons on existing work areas (click the "X" to remove).
+  - **Ctrl + Shift + Backspace**: Remove all work areas in the current image.
+  - **Ctrl + Alt**: Create temporary work area from current view (disappears when keys released).
+  - **Backspace**: Cancel drawing the current work area.
+  - **Mouse Movement**: Shows a preview of the work area while drawing.
+  - **Practical Use**:
+    - Define specific regions where models should make predictions
+    - Useful for processing only relevant parts of large images
+    - Work areas persist between tool changes and sessions
 
 ## Status Bar
 - **Image Size**: Displays the image size.


### PR DESCRIPTION
This pull request introduces enhancements to the `TileDataset` configuration UI and functionality, as well as significant updates to the `WorkAreaTool` for improved usability and flexibility. Additionally, documentation has been updated to reflect the new features and behavior. Below is a summary of the most important changes:

### Enhancements to `TileDataset` Configuration:

* Added a compression spinbox to the dataset configuration UI, allowing users to set compression levels for output files (0-100). This value is now passed to the tiling process (`compression` parameter). (`[[1]](diffhunk://#diff-3a28bf32444730b7af9f8e2aa91ee54c1e03c21078e648fbc3d7ff61f2200978R152-R164)`, `[[2]](diffhunk://#diff-3a28bf32444730b7af9f8e2aa91ee54c1e03c21078e648fbc3d7ff61f2200978R383)`, `[[3]](diffhunk://#diff-3a28bf32444730b7af9f8e2aa91ee54c1e03c21078e648fbc3d7ff61f2200978R447)`)
* Refactored the dataset configuration layout by grouping related options into separate sections (e.g., "Misc." group for miscellaneous options like "Include Negative Samples" and "Copy Source Data"). (`[coralnet_toolbox/Tile/TileDataset/QtBase.pyR208-R232](diffhunk://#diff-3a28bf32444730b7af9f8e2aa91ee54c1e03c21078e648fbc3d7ff61f2200978R208-R232)`)

### Improvements to `WorkAreaTool`:

* Introduced a temporary work area feature, activated with `Ctrl + Alt`. Temporary work areas are automatically removed when either key is released. (`[[1]](diffhunk://#diff-e73558d61f37d117ecf56df92ea237b2c5355ccbe45eec83ed6d4e9fd161d5bdR37)`, `[[2]](diffhunk://#diff-e73558d61f37d117ecf56df92ea237b2c5355ccbe45eec83ed6d4e9fd161d5bdL119-R202)`)
* Enhanced key handling for creating, managing, and removing work areas:
  - `Ctrl + Space`: Create a work area from the current view.
  - `Ctrl + Shift`: Show remove buttons for existing work areas.
  - `Ctrl + Shift + Backspace`: Remove all work areas.
  - [`Backspace`](diffhunk://#diff-e73558d61f37d117ecf56df92ea237b2c5355ccbe45eec83ed6d4e9fd161d5bdL119-R202): Cancel drawing the current work area. (`[coralnet_toolbox/Tools/QtWorkAreaTool.pyL119-R202](diffhunk://#diff-e73558d61f37d117ecf56df92ea237b2c5355ccbe45eec83ed6d4e9fd161d5bdL119-R202)`)

### Documentation Updates:

* Updated `docs/usage.md` to include the new key combinations and clarify the practical use of the `WorkAreaTool`, including the temporary work area feature and its benefits for large images. (`[docs/usage.mdL163-R174](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L163-R174)`)