### PR TITLE
Update work area data extraction to support BGR format

### DIFF
--- a/coralnet_toolbox/MachineLearning/DeployModel/QtDetect.py
+++ b/coralnet_toolbox/MachineLearning/DeployModel/QtDetect.py
@@ -254,7 +254,7 @@ class Detect(Base):
             work_areas_data = [raster.image_path]
         else:
             # Get the work areas
-            work_areas_data = raster.get_work_areas_data()
+            work_areas_data = raster.get_work_areas_data(as_format='BRG')
             
         return work_areas_data
 

--- a/coralnet_toolbox/MachineLearning/DeployModel/QtSegment.py
+++ b/coralnet_toolbox/MachineLearning/DeployModel/QtSegment.py
@@ -253,7 +253,7 @@ class Segment(Base):
             work_areas_data = [raster.image_path]
         else:
             # Get the work areas
-            work_areas_data = raster.get_work_areas_data()
+            work_areas_data = raster.get_work_areas_data(as_format='BRG')
             
         return work_areas_data
 

--- a/coralnet_toolbox/Rasters/QtRaster.py
+++ b/coralnet_toolbox/Rasters/QtRaster.py
@@ -4,6 +4,7 @@ import os
 import gc
 from typing import Optional, Set, List
 
+import cv2
 import rasterio
 import numpy as np
 
@@ -316,19 +317,26 @@ class Raster(QObject):
         else:
             return 1  # The entire image counts as one work item
     
-    def get_work_area_data(self, work_area):
+    def get_work_area_data(self, work_area, as_format='RGB'):
         """
-        Extract image data from a work area as a numpy array, with efficient downsampling.
+        Extract image data from a work area as a numpy array.
         
         Args:
-            work_area: WorkArea object or QRectF
-            longest_edge (int, optional): If provided, limits the longest edge to this size
-                while maintaining aspect ratio
+            work_area: WorkArea object or QRectF defining the area to extract
+            as_type (str): Format to return the data in, 'cv2' converts to BGR color format
                 
         Returns:
-            numpy.ndarray: Image data from the work area
+            numpy.ndarray: Image data from the work area, in BGR format if as_format='cv2',
+                           otherwise in RGB format
         """
-        return work_area_to_numpy(self._rasterio_src, work_area)
+        # Convert work area to numpy array
+        work_area_data = work_area_to_numpy(self._rasterio_src, work_area) 
+        
+        if as_format == 'BRG':
+            # Convert to RGB to BGR format for OpenCV
+            work_area_data = cv2.cvtColor(work_area_data, cv2.COLOR_RGB2BGR)
+            
+        return work_area_data
     
     def get_work_areas_data(self):
         """


### PR DESCRIPTION
This pull request introduces a new feature to support the BGR (Blue-Green-Red) color format in image processing workflows. The changes include updates to the `QtRaster` class to handle this new format and modifications to dependent methods to utilize the feature.

### New Feature: BGR Color Format Support

* **`QtRaster.py`: Enhanced `get_work_area_data` method**  
  - Added an optional `as_format` parameter to specify the desired color format (default is RGB).  
  - Implemented logic to convert image data to BGR format using OpenCV when `as_format='BRG'` is specified.  
  - Imported OpenCV (`cv2`) to enable color format conversion.

* **Dependent Methods Updated**  
  - Updated `_get_inputs` methods in `QtDetect.py` and `QtSegment.py` to call `get_work_areas_data` with `as_format='BRG'`, ensuring compatibility with the new BGR format. [[1]](diffhunk://#diff-c46750b718c0170356f9fb9e8135861c2e4fdb788738ae2200e31a1904af10ebL257-R257) [[2]](diffhunk://#diff-8be00e70e8d8306af5e3e2fb2c84e46fb95a2368cdfe7ffcb66452feef5e84baL256-R256)