### PR TITLE
fixed overlap input formlayout issue

### DIFF
--- a/coralnet_toolbox/Common/QtOverlapInput.py
+++ b/coralnet_toolbox/Common/QtOverlapInput.py
@@ -51,10 +51,22 @@ class OverlapInput(QGroupBox):
         self.height_double.setDecimals(2)
         self.height_double.hide()
 
-        layout.addRow("Width:", self.width_spin)
-        layout.addRow("", self.width_double)
-        layout.addRow("Height:", self.height_spin)
-        layout.addRow("", self.height_double)
+        # Instead of adding separate rows, create container widgets
+        width_container = QWidget()
+        width_layout = QHBoxLayout(width_container)
+        width_layout.setContentsMargins(0, 0, 0, 0)
+        width_layout.addWidget(self.width_spin)
+        width_layout.addWidget(self.width_double)
+
+        height_container = QWidget()
+        height_layout = QHBoxLayout(height_container)
+        height_layout.setContentsMargins(0, 0, 0, 0)
+        height_layout.addWidget(self.height_spin)
+        height_layout.addWidget(self.height_double)
+
+        # Add the containers as rows
+        layout.addRow("Width:", width_container)
+        layout.addRow("Height:", height_container)
 
         self.value_type.currentIndexChanged.connect(self.update_input_mode)
 


### PR DESCRIPTION
This pull request refactors the layout creation in the `QtOverlapInput` class to improve the organization and appearance of the UI components. The changes involve grouping related widgets into container widgets instead of adding them as separate rows.

UI layout improvements:

* [`coralnet_toolbox/Common/QtOverlapInput.py`](diffhunk://#diff-1b69f5d6aef6f1f3d139426a630aa7985b202bd6b69b09fbc1f9e06619555447L54-R69): Refactored the layout by introducing container widgets (`QWidget`) with horizontal layouts (`QHBoxLayout`) for width and height input fields. This replaces the previous approach of adding separate rows for each widget, improving the structure and maintainability of the UI.