### PR TITLE
Remove bad images from project

### DIFF
--- a/coralnet_toolbox/Rasters/QtRaster.py
+++ b/coralnet_toolbox/Rasters/QtRaster.py
@@ -142,7 +142,7 @@ class Raster(QObject):
     def get_qimage(self) -> Optional[QImage]:
         """
         Get or create the full-resolution QImage representation.
-        
+
         Returns:
             QImage or None: The image as QImage, or None if loading fails
         """
@@ -150,11 +150,27 @@ class Raster(QObject):
             try:
                 self._q_image = QImage(self.image_path)
                 if self._q_image.isNull():
-                    return None
+                    # Try using rasterio_to_qimage as a fallback
+                    if self._rasterio_src is not None:
+                        self._q_image = rasterio_to_qimage(self._rasterio_src)
+                        if self._q_image is None or self._q_image.isNull():
+                            return None
+                    else:
+                        return None
             except Exception as e:
                 print(f"Error loading QImage {self.image_path}: {str(e)}")
-                return None
-                
+                # Try using rasterio_to_qimage as a fallback
+                try:
+                    if self._rasterio_src is not None:
+                        self._q_image = rasterio_to_qimage(self._rasterio_src)
+                        if self._q_image is None or self._q_image.isNull():
+                            return None
+                    else:
+                        return None
+                except Exception as e2:
+                    print(f"Error loading QImage with rasterio for {self.image_path}: {str(e2)}")
+                    return None
+
         return self._q_image
     
     def get_thumbnail(self, longest_edge: int = 256) -> Optional[QImage]:


### PR DESCRIPTION
This pull request addresses error handling and fallback mechanisms for loading images in the `coralnet_toolbox` project. The changes improve robustness by adding fallback logic and user feedback when image loading fails.

### Error handling improvements:

* [`coralnet_toolbox/QtImageWindow.py`](diffhunk://#diff-10fc9b4c1a96cb0308cb24d9ac1c409cdb36ccce359f9e44eae1787ac69755cfL658-R665): Updated `load_image_by_path` to handle cases where the full-resolution image cannot be loaded. The problematic image is now removed, the UI is refreshed, and an error message is displayed to the user.

### Fallback mechanism for image loading:

* [`coralnet_toolbox/Rasters/QtRaster.py`](diffhunk://#diff-469beb2a8b52fb3737b15be28916ad2e001fc640ff204f134f278f67fb0a7ae1R153-R171): Enhanced `get_qimage` to use `rasterio_to_qimage` as a fallback if the primary method of loading an image fails. Added additional error handling and logging to ensure robustness during fallback attempts.