### PR TITLE
Fix typo in usage documentation for potential mislabels

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -106,7 +106,7 @@ The toolbox's training capabilities are powered by YOLOv8, the latest iteration 
 
 - **Decoupled Head:** The model uses separate neural network heads to perform the tasks of classification ("what is the object?") and regression ("what are the coordinates of its bounding box?"). This decoupling allows each head to specialize, which has become a mainstream best practice for achieving higher accuracy in modern object detectors.
 
-- **Advanced Loss Function:** YOLOv8 incorporates the Task-Aligned Assigner from the TOOD model, which uses a more sophisticated method for selecting the positive training examples for each ground-truth object. It also introduces the Distribution Focal Loss for the regression branch, which helps the model learn a more flexible and accurate representation of bounding box locations.
+- **Advanced Loss Function:** YOLOv8 incorporates the Task-Aligned Assigner, which uses a more sophisticated method for selecting the positive training examples for each ground-truth object. It also introduces the Distribution Focal Loss for the regression branch, which helps the model learn a more flexible and accurate representation of bounding box locations.
 
 YOLOv8 is offered in several sizes, typically denoted as n (nano), s (small), m (medium), l (large), and x (extra-large). Smaller models like YOLOv8n are extremely fast but less accurate, making them suitable for resource-constrained devices. Larger models like YOLOv8x are more accurate but slower and require more computational resources for training and inference. The toolbox allows users to select the model size that best fits their specific trade-off between speed and accuracy.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,7 +86,7 @@ The main window consists of several components:
       - **Scroll-wheel**: Zoom in and out of Embedding Viewer.
     - **Toolbar**:
       - **Isolate Selection**: Subset view;
-      - **Find Potentional Mislabels**: Select potentially incorrectly labeled annotations, based on location;
+      - **Find Potential Mislabels**: Select potentially incorrectly labeled annotations, based on location;
       - **Review Uncertain**: Select annotations with lower Top-1 confidence scores (requires Predictions);
       - **Home**: Resets the Embedding Viewer zoom level.
   **Tip**: 


### PR DESCRIPTION
This pull request includes minor textual corrections and refinements in the documentation to improve clarity and accuracy. The changes primarily address typographical errors and redundant phrasing.

### Documentation Refinements:

* [`docs/overview.md`](diffhunk://#diff-f23678b4c439fd130355644fa4c36770a302e257cc841883c4c11d74918e6e32L109-R109): Simplified the description of the Task-Aligned Assigner in YOLOv8 by removing redundant reference to the TOOD model.
* [`docs/usage.md`](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L89-R89): Corrected a typographical error in the toolbar description by changing "Find Potentional Mislabels" to "Find Potential Mislabels."