### PR TITLE
Yoloe updates

### DIFF
--- a/coralnet_toolbox/MachineLearning/ExportDataset/QtSegment.py
+++ b/coralnet_toolbox/MachineLearning/ExportDataset/QtSegment.py
@@ -53,6 +53,10 @@ class Segment(Base):
         self.include_rectangles_checkbox.setEnabled(True)  # Enable rectangles for segmentation
         self.include_polygons_checkbox.setChecked(True)
         self.include_polygons_checkbox.setEnabled(True)  # Enable user to uncheck polygons if desired
+        
+        # Explicitly enable negative sample options for segmentation
+        self.include_negatives_radio.setEnabled(True)
+        self.exclude_negatives_radio.setEnabled(True)
 
     def create_dataset(self, output_dir_path):
         """
@@ -106,12 +110,20 @@ class Segment(Base):
         Process and save segmentation annotations.
 
         Args:
-            annotations (list): List of annotations.
+            annotations (list): List of annotations for this split.
             split_dir (str): Path to the split directory.
             split (str): Split name (e.g., "Training", "Validation", "Testing").
         """
-        # Get unique image paths
-        image_paths = list(set(a.image_path for a in annotations))
+        # Determine the full list of images for this split (including negatives)
+        if split == "Training":
+            image_paths = self.train_images
+        elif split == "Validation":
+            image_paths = self.val_images
+        elif split == "Testing":
+            image_paths = self.test_images
+        else:
+            image_paths = []
+
         if not image_paths:
             return
 
@@ -124,6 +136,7 @@ class Segment(Base):
         for image_path in image_paths:
             yolo_annotations = []
             image_height, image_width = rasterio_open(image_path).shape
+            # Filter the annotations passed to this function to get only those for the current image
             image_annotations = [a for a in annotations if a.image_path == image_path]
 
             for image_annotation in image_annotations:
@@ -132,11 +145,11 @@ class Segment(Base):
                 yolo_annotations.append(f"{class_number} {annotation}")
 
             # Save the annotations to a text file
-            file_ext = image_path.split(".")[-1]
-            text_file = os.path.basename(image_path).replace(f".{file_ext}", ".txt")
+            file_ext = os.path.splitext(image_path)[1]
+            text_file = os.path.basename(image_path).replace(file_ext, ".txt")
             text_path = os.path.join(f"{split_dir}/labels", text_file)
 
-            # Write the annotations to the text file
+            # Write the annotations to the text file (creates an empty file for negatives)
             with open(text_path, 'w') as f:
                 for annotation in yolo_annotations:
                     f.write(annotation + '\n')
@@ -146,7 +159,7 @@ class Segment(Base):
 
             progress_bar.update_progress()
 
-        # Make cursor normal
+        # Reset cursor
         QApplication.restoreOverrideCursor()
         progress_bar.stop_progress()
         progress_bar.close()

--- a/coralnet_toolbox/Rasters/QtRaster.py
+++ b/coralnet_toolbox/Rasters/QtRaster.py
@@ -307,8 +307,9 @@ class Raster(QObject):
             label_match = False
             
             # Check actual annotation labels (always consider these)
-            for label in self.labels:
-                if hasattr(label, 'short_label_code') and search_label in label.short_label_code:
+            # Look for the search label in the label_set instead of self.labels
+            for label_code in self.label_set:
+                if search_label in label_code:
                     label_match = True
                     break
             


### PR DESCRIPTION
This pull request introduces several updates to improve functionality, error handling, and code clarity across multiple modules in the `coralnet_toolbox`. The key changes include enabling negative sample options for segmentation, refining annotation processing logic, improving error handling in dialogs, and enhancing code readability and maintainability.

### Enhancements to segmentation dataset export:
* Enabled negative sample options in the `update_annotation_type_checkboxes` method by activating the `include_negatives_radio` and `exclude_negatives_radio` controls.
* Refined the `process_annotations` method to:
  - Use predefined image lists (`train_images`, `val_images`, `test_images`) for splits instead of extracting unique paths from annotations.
  - Filter annotations per image before processing, ensuring only relevant annotations are handled.
  - Handle file extensions more robustly using `os.path.splitext` and create empty annotation files for negative samples.
  - Reset the cursor properly after processing annotations.

### Improvements to raster filtering:
* Updated the `matches_filter` method in `QtRaster.py` to search within `label_set` instead of `self.labels`, simplifying the logic and improving performance.

### Enhanced error handling in dialogs:
* Added calls to `super().reject()` in the `accept` method of `QtDeployGenerator.py` to ensure the dialog safely closes when validation fails (e.g., missing model, source label, or target images). [[1]](diffhunk://#diff-30707411cbcb5e0153ceeb359f6028840e0d2672c34048a96eaef80cdb7cc39eR263-R271) [[2]](diffhunk://#diff-30707411cbcb5e0153ceeb359f6028840e0d2672c34048a96eaef80cdb7cc39eR281)
* Used a `QTimer.singleShot` mechanism in `update_source_labels` to safely reject the dialog if no valid reference annotations are found, avoiding instability during event processing.