### PR TITLE
fixed coralnet download bug

### DIFF
--- a/coralnet_toolbox/CoralNet/QtDownload.py
+++ b/coralnet_toolbox/CoralNet/QtDownload.py
@@ -946,7 +946,8 @@ class DownloadDialog(QDialog):
 
                 try:
                     # Check if there is a next page button and it's enabled
-                    element_text = 'form.no-padding [type="submit"][value=">"]'
+                    # ---- THIS IS THE MODIFIED LINE ----
+                    element_text = 'a[title="Next page"]'
 
                     try:
                         next_button = self.driver.find_element(By.CSS_SELECTOR, element_text)


### PR DESCRIPTION
This pull request makes a small but important change to the way the "next page" button is selected in the `get_images` method of `QtDownload.py`. The selector was updated to more accurately target the "Next page" button.

* Updated the CSS selector used to find the "Next page" button from `'form.no-padding [type="submit"][value=">"]'` to `'a[title="Next page"]'` in the `get_images` method of `coralnet_toolbox/CoralNet/QtDownload.py`