### PR TITLE
Todos

### DIFF
--- a/coralnet_toolbox/SAM/QtDeployGenerator.py
+++ b/coralnet_toolbox/SAM/QtDeployGenerator.py
@@ -168,7 +168,7 @@ class DeployGeneratorDialog(QDialog):
 
         # Image size control
         self.imgsz_spinbox = QSpinBox()
-        self.imgsz_spinbox.setRange(512, 65536)
+        self.imgsz_spinbox.setRange(1024, 65536)
         self.imgsz_spinbox.setSingleStep(1024)
         self.imgsz_spinbox.setValue(self.imgsz)
         layout.addRow("Image Size (imgsz):", self.imgsz_spinbox)

--- a/coralnet_toolbox/SAM/QtDeployGenerator.py
+++ b/coralnet_toolbox/SAM/QtDeployGenerator.py
@@ -460,9 +460,6 @@ class DeployGeneratorDialog(QDialog):
             progress_bar.stop_progress()
             progress_bar.close()
 
-        # Exit the dialog box
-        self.accept()
-
     def get_imgsz(self):
         """Get the image size for the model."""
         self.imgsz = self.imgsz_spinbox.value()

--- a/coralnet_toolbox/SAM/QtDeployPredictor.py
+++ b/coralnet_toolbox/SAM/QtDeployPredictor.py
@@ -158,7 +158,7 @@ class DeployPredictorDialog(QDialog):
 
         # Image size control
         self.imgsz_spinbox = QSpinBox()
-        self.imgsz_spinbox.setRange(512, 65536)
+        self.imgsz_spinbox.setRange(1024, 65536)
         self.imgsz_spinbox.setSingleStep(1024)
         self.imgsz_spinbox.setValue(self.imgsz)
         layout.addRow("Image Size (imgsz):", self.imgsz_spinbox)

--- a/coralnet_toolbox/SeeAnything/QtDeployGenerator.py
+++ b/coralnet_toolbox/SeeAnything/QtDeployGenerator.py
@@ -416,7 +416,7 @@ class DeployGeneratorDialog(QDialog):
 
         # Image size control
         self.imgsz_spinbox = QSpinBox()
-        self.imgsz_spinbox.setRange(512, 65536)
+        self.imgsz_spinbox.setRange(1024, 65536)
         self.imgsz_spinbox.setSingleStep(1024)
         self.imgsz_spinbox.setValue(self.imgsz)
         layout.addRow("Image Size (imgsz):", self.imgsz_spinbox)

--- a/coralnet_toolbox/SeeAnything/QtDeployPredictor.py
+++ b/coralnet_toolbox/SeeAnything/QtDeployPredictor.py
@@ -322,6 +322,7 @@ class DeployPredictorDialog(QDialog):
     def is_sam_model_deployed(self):
         """
         Check if the SAM model is deployed and update the checkbox state accordingly.
+        If SAM is enabled for polygons, sync and disable the imgsz spinbox.
 
         :return: Boolean indicating whether the SAM model is deployed
         """
@@ -334,8 +335,47 @@ class DeployPredictorDialog(QDialog):
             self.use_sam_dropdown.setCurrentText("False")
             QMessageBox.critical(self, "Error", "Please deploy the SAM model first.")
             return False
+        
+        # Check if SAM polygons are enabled
+        if self.use_sam_dropdown.currentText() == "True":
+            # Sync the imgsz spinbox with SAM's value
+            self.imgsz_spinbox.setValue(self.sam_dialog.imgsz_spinbox.value())
+            # Disable the spinbox
+            self.imgsz_spinbox.setEnabled(False)
+            
+            # Connect SAM's imgsz_spinbox valueChanged signal to update our value
+            # First disconnect any existing connection to avoid duplicates
+            try:
+                self.sam_dialog.imgsz_spinbox.valueChanged.disconnect(self.update_from_sam_imgsz)
+            except TypeError:
+                # No connection exists yet
+                pass
+            
+            # Connect the signal
+            self.sam_dialog.imgsz_spinbox.valueChanged.connect(self.update_from_sam_imgsz)
+        else:
+            # Re-enable the spinbox when SAM polygons are disabled
+            self.imgsz_spinbox.setEnabled(True)
+            
+            # Disconnect the signal when SAM is disabled
+            try:
+                self.sam_dialog.imgsz_spinbox.valueChanged.disconnect(self.update_from_sam_imgsz)
+            except TypeError:
+                # No connection exists
+                pass
 
         return True
+
+    def update_from_sam_imgsz(self, value):
+        """
+        Update the SeeAnything image size when SAM's image size changes.
+        Only takes effect when SAM polygons are enabled.
+        
+        Args:
+            value (int): The new image size value from SAM dialog
+        """
+        if self.use_sam_dropdown.currentText() == "True":
+            self.imgsz_spinbox.setValue(value)
 
     def load_model(self):
         """

--- a/coralnet_toolbox/SeeAnything/QtDeployPredictor.py
+++ b/coralnet_toolbox/SeeAnything/QtDeployPredictor.py
@@ -171,7 +171,7 @@ class DeployPredictorDialog(QDialog):
         # Image size control
         self.imgsz_spinbox = QSpinBox()
         self.imgsz_spinbox.setRange(512, 65536)
-        self.imgsz_spinbox.setSingleStep(256)
+        self.imgsz_spinbox.setSingleStep(1024)
         self.imgsz_spinbox.setValue(self.imgsz)
         layout.addRow("Image Size (imgsz)", self.imgsz_spinbox)
 

--- a/coralnet_toolbox/Tools/QtRectangleTool.py
+++ b/coralnet_toolbox/Tools/QtRectangleTool.py
@@ -113,6 +113,36 @@ class RectangleTool(Tool):
         # Ensure top_left and bottom_right are correctly calculated
         top_left = QPointF(min(self.start_point.x(), end_point.x()), min(self.start_point.y(), end_point.y()))
         bottom_right = QPointF(max(self.start_point.x(), end_point.x()), max(self.start_point.y(), end_point.y()))
+        
+        # Calculate width and height of the rectangle
+        width = bottom_right.x() - top_left.x()
+        height = bottom_right.y() - top_left.y()
+        
+        # Define minimum dimensions for a valid rectangle (e.g., 3x3 pixels)
+        MIN_DIMENSION = 3.0
+        
+        # If rectangle is too small and we're finalizing it, enforce minimum size
+        if finished and (width < MIN_DIMENSION or height < MIN_DIMENSION):
+            if width < MIN_DIMENSION:
+                # Expand width while maintaining center
+                center_x = (top_left.x() + bottom_right.x()) / 2
+                top_left.setX(center_x - MIN_DIMENSION / 2)
+                bottom_right.setX(center_x + MIN_DIMENSION / 2)
+                
+            if height < MIN_DIMENSION:
+                # Expand height while maintaining center
+                center_y = (top_left.y() + bottom_right.y()) / 2
+                top_left.setY(center_y - MIN_DIMENSION / 2)
+                bottom_right.setY(center_y + MIN_DIMENSION / 2)
+            
+            # Show a message if we had to adjust a very small rectangle
+            if width < 1 or height < 1:
+                QMessageBox.information(
+                    self.annotation_window, 
+                    "Rectangle Adjusted",
+                    f"The rectangle was too small and has been adjusted to a minimum size of "
+                    f"{MIN_DIMENSION}x{MIN_DIMENSION} pixels."
+                )
 
         # Create the rectangle annotation
         annotation = RectangleAnnotation(top_left,


### PR DESCRIPTION
This pull request introduces several improvements to annotation tools and model parameter controls, focusing on input validation, user experience, and synchronization between related UI components. The most significant changes include enforcing minimum sizes for polygons and rectangles, synchronizing image size controls between models, and improving the robustness of annotation centering and zooming.

**Annotation input validation and usability:**

* Added validation in `QtPolygonTool.py` to filter out duplicate or near-duplicate points when creating polygons, and to automatically generate a minimum-sized polygon if too few unique points are provided, with user notification.
* Enforced a minimum rectangle size in `QtRectangleTool.py` by expanding rectangles that are too small upon creation, and notifying the user if an adjustment was necessary.

**Image size parameter controls and synchronization:**

* Increased the minimum allowed image size (`imgsz_spinbox`) from 512 to 1024 pixels in all relevant model deployment and prediction dialogs, and standardized the step size to 1024 where appropriate. [[1]](diffhunk://#diff-c3e47a3c760761b8e26ea9e49bde878bc8c354126d74c492c380bbb6592c18bbL171-R171) [[2]](diffhunk://#diff-56c86b14fe9b83a706afcaff9ba0ffb5bcc1404584210b01f77f9ce153c137c4L161-R161) [[3]](diffhunk://#diff-30707411cbcb5e0153ceeb359f6028840e0d2672c34048a96eaef80cdb7cc39eL419-R419) [[4]](diffhunk://#diff-b9e9969801a0fa3841514ec018a50a9cfcd294d7532ce6ae1c43ec5ec7127d40L174-R174)
* In `SeeAnything/QtDeployPredictor.py`, when SAM polygons are enabled, the image size spinbox is now synchronized with the SAM model's image size and disabled to prevent user edits, with dynamic updates if the SAM value changes. The spinbox is re-enabled and unsynchronized when SAM polygons are disabled. [[1]](diffhunk://#diff-b9e9969801a0fa3841514ec018a50a9cfcd294d7532ce6ae1c43ec5ec7127d40R325) [[2]](diffhunk://#diff-b9e9969801a0fa3841514ec018a50a9cfcd294d7532ce6ae1c43ec5ec7127d40R339-R379)

**Annotation view and zoom improvements:**

* Improved the robustness of the annotation centering logic in `QtAnnotationWindow.py` by enforcing minimum padding values, preventing zero-width/height errors, and adding safety checks to the zoom factor calculation. [[1]](diffhunk://#diff-a48a86cfcca465ea4cb8674b2532f2a2560ac3727a5f1a65ec28baea21cd631bL495-L497) [[2]](diffhunk://#diff-a48a86cfcca465ea4cb8674b2532f2a2560ac3727a5f1a65ec28baea21cd631bL506-R523)

**Other UI/UX adjustments:**

* Removed the automatic closing of the dialog after model loading in `SAM/QtDeployGenerator.py` to give users more control over the dialog flow.