### PR TITLE
VideoPlayer

### DIFF
--- a/coralnet_toolbox/IO/QtImportVideo.py
+++ b/coralnet_toolbox/IO/QtImportVideo.py
@@ -1,0 +1,62 @@
+import warnings
+
+from PyQt5.QtCore import QObject, Qt
+from PyQt5.QtWidgets import QFileDialog, QMessageBox, QApplication
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Classes
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class ImportVideo(QObject):
+    """
+    Handles importing a video file as a first-class VideoRaster in the project.
+    The video appears as a single row in the ImageWindow.  Per-frame annotations
+    are stored under virtual paths of the form 'video.mp4::frame_N'.
+    """
+
+    def __init__(self, main_window):
+        super().__init__(main_window)
+        self.main_window = main_window
+
+    def import_video(self):
+        """Open a file dialog and import the selected video file."""
+        file_filter = "Video Files (*.mp4 *.avi *.mov *.mkv *.webm *.MP4 *.AVI *.MOV *.MKV *.WEBM)"
+        video_path, _ = QFileDialog.getOpenFileName(
+            self.main_window,
+            "Import Video",
+            "",
+            file_filter,
+        )
+        if not video_path:
+            return
+
+        # Make cursor busy
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+
+        try:
+            success = self.main_window.image_window.raster_manager.add_video_raster(video_path)
+        except Exception as e:
+            success = False
+            print(f"ImportVideo error: {e}")
+        finally:
+            QApplication.restoreOverrideCursor()
+
+        if not success:
+            QMessageBox.warning(
+                self.main_window,
+                "Import Failed",
+                f"Could not open video file:\n{video_path}\n\n"
+                "Ensure the file is a valid video and OpenCV has the required codec.",
+            )
+            return
+
+        # Refresh the ImageWindow list
+        try:
+            self.main_window.image_window.update_search_bars()
+            self.main_window.image_window.filter_images(use_threading=False)
+        except Exception:
+            pass

--- a/coralnet_toolbox/IO/QtOpenProject.py
+++ b/coralnet_toolbox/IO/QtOpenProject.py
@@ -222,8 +222,16 @@ class OpenProject(QDialog):
 
             # Add images directly to the manager without emitting signals
             for path in image_paths:
-                # Call the manager directly to add the raster silently
-                self.image_window.raster_manager.add_raster(path, emit_signal=False) 
+                # Check if this is a saved VideoRaster
+                is_video = False
+                if is_new_format and path in image_data_map:
+                    is_video = image_data_map[path].get('type') == 'VideoRaster'
+
+                if is_video:
+                    self.image_window.raster_manager.add_video_raster(path)
+                else:
+                    # Call the manager directly to add the raster silently
+                    self.image_window.raster_manager.add_raster(path, emit_signal=False)
                 
                 raster = self.image_window.raster_manager.get_raster(path)
                 if not raster:
@@ -366,6 +374,25 @@ class OpenProject(QDialog):
                     if image_path in self.updated_paths:
                         image_path = self.updated_paths[image_path]
                         updated_path = True
+                    elif '::frame_' in image_path:
+                        # Virtual video frame path — valid if the base video is loaded
+                        base_video = image_path.rsplit('::frame_', 1)[0]
+                        # Also check updated_paths for the base video
+                        resolved_video = self.updated_paths.get(base_video, base_video)
+                        if resolved_video not in raster_manager.image_paths:
+                            print(f"Warning: Video not found for frame path: {image_path}")
+                            skipped_count += len(image_annotations)
+                            progress_batch += len(image_annotations)
+                            if progress_batch >= PROGRESS_BATCH_SIZE:
+                                for _ in range(progress_batch):
+                                    progress_bar.update_progress()
+                                progress_batch = 0
+                            continue
+                        # If base video path was remapped, update the virtual path too
+                        if resolved_video != base_video:
+                            frame_num = image_path.rsplit('::frame_', 1)[1]
+                            image_path = f"{resolved_video}::frame_{frame_num}"
+                            updated_path = True
                     else:
                         print(f"Warning: Image not found: {image_path}")
                         skipped_count += len(image_annotations)
@@ -477,6 +504,21 @@ class OpenProject(QDialog):
             # Ensure progress bar completes
             progress_bar.stop_progress()
             progress_bar.close()
+
+            # Force the ImageWindow table to repaint annotation counts.
+            # dataChanged signals may be queued; an explicit viewport update ensures
+            # counts are visible without requiring a resize event.
+            try:
+                self.image_window.tableView.viewport().update()
+            except Exception:
+                pass
+
+            # Refresh video tick marks if a video is already active in the canvas.
+            try:
+                self.annotation_window._update_video_annotation_marks()
+            except Exception:
+                pass
+
             try:
                 self.main_window.status_bar.showMessage("Import complete.", 3000)
             except Exception:

--- a/coralnet_toolbox/IO/__init__.py
+++ b/coralnet_toolbox/IO/__init__.py
@@ -1,5 +1,6 @@
 from .QtImportImages import ImportImages
 from .QtImportFrames import ImportFrames
+from .QtImportVideo import ImportVideo
 from .QtImportLabels import ImportLabels
 from .QtImportCoralNetLabels import ImportCoralNetLabels
 from .QtImportTagLabLabels import ImportTagLabLabels
@@ -25,6 +26,7 @@ from .QtSaveProject import SaveProject
 __all__ = [
     'ImportImages',
     'ImportFrames',
+    'ImportVideo',
     'ImportLabels',
     'ImportCoralNetLabels',
     'ImportTagLabLabels',

--- a/coralnet_toolbox/QtAnnotationWindow.py
+++ b/coralnet_toolbox/QtAnnotationWindow.py
@@ -60,7 +60,9 @@ from coralnet_toolbox.Icons import ColorComboBox
 from coralnet_toolbox.Icons import ColormapDelegate
 
 from coralnet_toolbox.utilities import rasterio_open
-from coralnet_toolbox.utilities import convert_scale_units 
+from coralnet_toolbox.utilities import convert_scale_units
+
+from coralnet_toolbox.QtVideoPlayer import VideoPlayerWidget
 
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -133,6 +135,15 @@ class AnnotationWindow(BaseCanvas):
         self.dynamic_range_timer = self._dynamic_range_timer  # Reference BaseCanvas timer
         self.dynamic_range_update_delay = 100  # milliseconds
 
+        # Video playback state
+        self._active_video_raster = None   # VideoRaster when a video is loaded
+        self._current_frame_idx: int = 0
+        self._video_player = VideoPlayerWidget(self)
+        self._playback_timer = QTimer(self)
+        self._playback_timer.timeout.connect(self._playback_tick)
+        # Video toolbar is created lazily via create_video_toolbar()
+        self._video_toolbar = None
+
         # Connect signals to slots
         self.toolChanged.connect(self.set_selected_tool)
         
@@ -147,6 +158,10 @@ class AnnotationWindow(BaseCanvas):
         self.annotationModified.connect(self.annotation_manager.annotationModified)
         self.annotationLabelChanged.connect(self.annotation_manager.annotationLabelChanged)
         self.annotationSelectionChanged.connect(self.annotation_manager.selectionChanged)
+
+        # Keep video scrub-bar tick marks in sync with annotation changes
+        self.annotationCreated.connect(self._on_annotation_change_for_video)
+        self.annotationDeleted.connect(self._on_annotation_change_for_video)
         
         # Initialize toolbar and status bar widgets
         self._init_toolbar_widgets()  # Likely causes an error
@@ -585,6 +600,16 @@ class AnnotationWindow(BaseCanvas):
         # Restore cursor
         QApplication.restoreOverrideCursor()
         
+    # --- VIDEO TOOLBAR HOOK ---
+    def create_video_toolbar(self) -> QToolBar:
+        """Create the video player toolbar (hidden until a VideoRaster is loaded)."""
+        toolbar = QToolBar("Video Player")
+        toolbar.setMovable(False)
+        toolbar.addWidget(self._video_player)
+        toolbar.setVisible(False)
+        self._video_toolbar = toolbar
+        return toolbar
+
     # --- DOCK WRAPPER HOOKS ---
     def create_top_toolbar(self) -> QToolBar:
         """Create the top toolbar with annotation tools and transparency slider.
@@ -934,6 +959,7 @@ class AnnotationWindow(BaseCanvas):
         
         if self.active_image and self.selected_tool:
             self.tools[self.selected_tool].keyPressEvent(event)
+
         super().keyPressEvent(event)
 
     def keyReleaseEvent(self, event):
@@ -941,6 +967,338 @@ class AnnotationWindow(BaseCanvas):
         if self.active_image and self.selected_tool:
             self.tools[self.selected_tool].keyReleaseEvent(event)
         super().keyReleaseEvent(event)
+
+    # =========================================================================
+    # VIDEO MODE
+    # =========================================================================
+
+    def _clear_annotation_graphics_single(self, annotation):
+        """Strip all graphics references from a single annotation without crashing."""
+        try:
+            if (hasattr(annotation, 'graphics_item_group') and
+                    annotation.graphics_item_group is not None):
+                try:
+                    if annotation.graphics_item_group.scene():
+                        annotation.graphics_item_group.scene().removeItem(
+                            annotation.graphics_item_group
+                        )
+                except RuntimeError:
+                    pass
+            annotation.graphics_item_group = None
+            annotation.graphics_item = None
+            annotation.center_graphics_item = None
+            annotation.bounding_box_graphics_item = None
+            if hasattr(annotation, 'tag_item'):
+                annotation.tag_item = None
+            if hasattr(annotation, 'dimension_tag_item'):
+                annotation.dimension_tag_item = None
+            annotation.is_selected = False
+        except Exception:
+            pass
+
+    def _on_annotation_change_for_video(self, *args):
+        """Slot called when annotations are created or deleted; refreshes scrub-bar ticks."""
+        if self._active_video_raster is not None:
+            self._update_video_annotation_marks()
+
+    def _get_annotated_frame_indices(self) -> set:
+        """Return the set of frame indices that have at least one annotation for the active video."""
+        if self._active_video_raster is None:
+            return set()
+        prefix = self._active_video_raster.image_path + '::frame_'
+        frame_indices = set()
+        for key, annotations in self.image_annotations_dict.items():
+            if key.startswith(prefix) and annotations:
+                try:
+                    frame_indices.add(int(key.split('::frame_', 1)[1]))
+                except (ValueError, IndexError):
+                    pass
+        return frame_indices
+
+    def _update_video_annotation_marks(self):
+        """Compute which frame indices have annotations and push them to the player slider."""
+        self._video_player.update_annotation_marks(self._get_annotated_frame_indices())
+
+    def _activate_video_mode(self, video_raster):
+        """Switch the annotation window into video mode for the given VideoRaster."""
+        # If already active for the same raster, just ensure player is visible
+        if self._active_video_raster is video_raster:
+            if self._video_toolbar is not None:
+                self._video_toolbar.setVisible(True)
+            return
+
+        # Stop any existing playback
+        self._playback_timer.stop()
+
+        self._active_video_raster = video_raster
+        self._current_frame_idx = 0
+
+        # Show the video player toolbar
+        if self._video_toolbar is not None:
+            self._video_toolbar.setVisible(True)
+
+        # Connect player signals (disconnect first to avoid duplicates)
+        try:
+            self._video_player.seekChanged.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.playClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.pauseClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.nextFrameClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.prevFrameClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.nextAnnotatedClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.prevAnnotatedClicked.disconnect()
+        except Exception:
+            pass
+
+        self._video_player.seekChanged.connect(self._on_video_seek)
+        self._video_player.playClicked.connect(self._on_video_play)
+        self._video_player.pauseClicked.connect(self._on_video_pause)
+        self._video_player.nextFrameClicked.connect(self._on_video_next)
+        self._video_player.prevFrameClicked.connect(self._on_video_prev)
+        self._video_player.nextAnnotatedClicked.connect(self._on_video_next_annotated)
+        self._video_player.prevAnnotatedClicked.connect(self._on_video_prev_annotated)
+
+        # Reset player state
+        self._video_player.reset()
+
+        # Display frame 0
+        self._display_video_frame(0)
+
+        # Populate tick marks for any pre-existing annotations
+        self._update_video_annotation_marks()
+
+    def _deactivate_video_mode(self):
+        """Leave video mode (called when switching to a regular image)."""
+        if self._active_video_raster is None:
+            return
+
+        self._playback_timer.stop()
+        self._video_player.set_paused()
+
+        # Disconnect player signals
+        try:
+            self._video_player.seekChanged.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.playClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.pauseClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.nextFrameClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.prevFrameClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.nextAnnotatedClicked.disconnect()
+        except Exception:
+            pass
+        try:
+            self._video_player.prevAnnotatedClicked.disconnect()
+        except Exception:
+            pass
+
+        self._video_player.reset()
+        self.main_window.set_video_playback_tools_enabled(True)
+
+        if self._video_toolbar is not None:
+            self._video_toolbar.setVisible(False)
+
+        self._active_video_raster = None
+        self._current_frame_idx = 0
+
+    def _display_video_frame(self, frame_idx: int):
+        """
+        Full display path: load frame, run load_visuals, load annotations.
+        Only called on seek/pause (not during playback).
+        """
+        video_raster = self._active_video_raster
+        if video_raster is None:
+            return
+
+        frame_idx = max(0, min(frame_idx, video_raster.frame_count - 1))
+        self._current_frame_idx = frame_idx
+
+        # Build the virtual path that serves as this frame's image_path key
+        virtual_path = video_raster.make_frame_path(video_raster.image_path, frame_idx)
+
+        # Get the frame QImage
+        q_image = video_raster.get_frame(frame_idx)
+        if q_image is None or q_image.isNull():
+            return
+
+        # Make sure rasterio_image is set for annotation cropping
+        self.rasterio_image = video_raster.rasterio_src
+
+        # Use BaseCanvas canonical loader (clears scene, sets pixmap, fits view)
+        self.load_visuals(q_image, virtual_path, None)
+
+        # Restore cursor (load_visuals may not set it)
+        self.active_image = True
+
+        # Update status bar dimensions
+        self.imageLoaded.emit(video_raster.width, video_raster.height)
+        self.viewChanged.emit(video_raster.width, video_raster.height)
+
+        # Load annotations for this virtual frame path
+        self.load_annotations()
+
+        # Refresh scrub-bar tick marks (cheap; only runs on seek/pause, not playback)
+        self._update_video_annotation_marks()
+
+        # Update the player widget state
+        self._video_player.update_state(frame_idx, video_raster.frame_count)
+
+    def _on_video_seek(self, frame_idx: int):
+        """Handle slider seek: stop playback, display frame."""
+        self._playback_timer.stop()
+        if self._video_player.is_playing:
+            self._video_player.set_paused()
+            self.main_window.set_video_playback_tools_enabled(True)
+        self._display_video_frame(frame_idx)
+
+    def _on_video_play(self):
+        """Start the playback timer, clearing annotation graphics first."""
+        if self._active_video_raster is None:
+            return
+        # Remove annotation graphics for the current frame from the scene.
+        # The annotation data is preserved; graphics are rebuilt on pause.
+        self._clear_current_frame_annotation_graphics()
+        self.main_window.set_video_playback_tools_enabled(False)
+        fps = self._active_video_raster.fps
+        interval = max(1, int(1000 / fps))
+        self._playback_timer.start(interval)
+
+    def _clear_current_frame_annotation_graphics(self):
+        """Remove annotation graphics items for the current frame from the scene.
+        Annotation data is kept intact so they reload correctly on pause."""
+        path = self.current_image_path
+        if not path:
+            return
+        for annotation in list(self.image_annotations_dict.get(path, [])):
+            try:
+                # Remove the group from the scene first
+                if (hasattr(annotation, 'graphics_item_group') and
+                        annotation.graphics_item_group is not None):
+                    try:
+                        if annotation.graphics_item_group.scene():
+                            annotation.graphics_item_group.scene().removeItem(
+                                annotation.graphics_item_group
+                            )
+                    except RuntimeError:
+                        pass  # C++ object already deleted
+
+                # Null out ALL graphics item references so deselect() / delete()
+                # don't try to operate on dangling C++ objects
+                annotation.graphics_item_group = None
+                annotation.graphics_item = None
+                annotation.center_graphics_item = None
+                annotation.bounding_box_graphics_item = None
+                if hasattr(annotation, 'tag_item'):
+                    annotation.tag_item = None
+                if hasattr(annotation, 'dimension_tag_item'):
+                    annotation.dimension_tag_item = None
+
+                # Mark as deselected so unselect_annotations() skips the deselect path
+                annotation.is_selected = False
+            except Exception:
+                pass
+
+    def _on_video_pause(self):
+        """Stop the timer and do a full frame redisplay with annotations."""
+        self._playback_timer.stop()
+        self.main_window.set_video_playback_tools_enabled(True)
+        self._display_video_frame(self._current_frame_idx)
+
+    def _on_video_next(self):
+        """Advance one frame."""
+        if self._active_video_raster is None:
+            return
+        next_idx = min(self._current_frame_idx + 1, self._active_video_raster.frame_count - 1)
+        self._display_video_frame(next_idx)
+
+    def _on_video_prev(self):
+        """Step back one frame."""
+        if self._active_video_raster is None:
+            return
+        prev_idx = max(self._current_frame_idx - 1, 0)
+        self._display_video_frame(prev_idx)
+
+    def _on_video_next_annotated(self):
+        """Jump to the nearest annotated frame after the current position."""
+        if self._active_video_raster is None:
+            return
+        candidates = [f for f in self._get_annotated_frame_indices() if f > self._current_frame_idx]
+        if candidates:
+            self._display_video_frame(min(candidates))
+
+    def _on_video_prev_annotated(self):
+        """Jump to the nearest annotated frame before the current position."""
+        if self._active_video_raster is None:
+            return
+        candidates = [f for f in self._get_annotated_frame_indices() if f < self._current_frame_idx]
+        if candidates:
+            self._display_video_frame(max(candidates))
+
+    def _playback_tick(self):
+        """
+        Fast playback path: update the scene pixmap only — no annotation load.
+        Annotations are only loaded when playback pauses.
+        """
+        if self._active_video_raster is None:
+            self._playback_timer.stop()
+            return
+
+        next_idx = (self._current_frame_idx + 1) % self._active_video_raster.frame_count
+        q_image = self._active_video_raster.get_frame(next_idx)
+        if q_image is None:
+            return
+
+        self._current_frame_idx = next_idx
+
+        # Keep current_image_path in sync so pause knows which frame to reload
+        self.current_image_path = self._active_video_raster.make_frame_path(
+            self._active_video_raster.image_path, next_idx
+        )
+
+        # Swap pixmap in-place — cheap paint, no scene rebuild
+        if self._base_image_item is not None:
+            self._base_image_item.setPixmap(QPixmap.fromImage(q_image))
+        else:
+            # Fallback: use the full display path (slower but correct)
+            self.load_visuals(q_image, self.current_image_path, None)
+
+        # Update slider silently
+        self._video_player.slider.blockSignals(True)
+        self._video_player.slider.setValue(next_idx)
+        self._video_player.slider.blockSignals(False)
+        self._video_player.lbl_frame.setText(
+            f"{next_idx} / {self._active_video_raster.frame_count}"
+        )
 
     def cursorInWindow(self, pos, mapped=False):
         """Check if the cursor position is within the image bounds."""
@@ -1417,6 +1775,30 @@ class AnnotationWindow(BaseCanvas):
             self.tools[self.selected_tool].stop_current_drawing()
             if self.selected_tool in ["scale"]:
                 self.main_window.untoggle_all_tools()
+
+        # ---- VIDEO BRANCH ----
+        # Resolve virtual frame paths to the underlying video path for the raster lookup
+        lookup_path = image_path
+        if '::frame_' in image_path:
+            lookup_path = image_path.rsplit('::frame_', 1)[0]
+
+        raster_check = self.main_window.image_window.raster_manager.get_raster(lookup_path)
+
+        # Import here to avoid circular imports at module level
+        try:
+            from coralnet_toolbox.Rasters.VideoRaster import VideoRaster as _VideoRaster
+            _video_raster_cls = _VideoRaster
+        except ImportError:
+            _video_raster_cls = None
+
+        if _video_raster_cls is not None and isinstance(raster_check, _video_raster_cls):
+            QApplication.restoreOverrideCursor()
+            self._activate_video_mode(raster_check)
+            return
+        else:
+            # Deactivate video mode if we're switching to a regular image
+            self._deactivate_video_mode()
+        # ---- END VIDEO BRANCH ----
                     
         # Clean up (This is the ONLY scene clear)
         self.clear_scene()
@@ -2386,8 +2768,13 @@ class AnnotationWindow(BaseCanvas):
             # Set the visibility based on the current UI state (will respect label checkbox)
             self.set_annotation_visibility(annotation)
             
-            # Force the screen to instantly show the newly drawn item
-            self.viewport().update()
+            # If video is currently playing, immediately strip the graphics we just created
+            # so the annotation doesn't ghost over the advancing frames.
+            if self._playback_timer.isActive():
+                self._clear_annotation_graphics_single(annotation)
+            else:
+                # Force the screen to instantly show the newly drawn item
+                self.viewport().update()
 
         # --- Finalization ---
         # Update the annotation count in the ImageWindow table (always, regardless of visibility)
@@ -2595,7 +2982,13 @@ class AnnotationWindow(BaseCanvas):
 
     def delete_image_annotations(self, image_path):
         """Delete all annotations associated with a specific image path (Bulk Optimized)."""
+        # For VideoRaster base paths, annotations live under ::frame_ virtual keys.
+        # Recurse over every frame key so the caller doesn't need to know about them.
         if image_path not in self.image_annotations_dict:
+            prefix = image_path + '::frame_'
+            frame_keys = [k for k in list(self.image_annotations_dict.keys()) if k.startswith(prefix)]
+            for frame_key in frame_keys:
+                self.delete_image_annotations(frame_key)
             return
 
         # 1. Access label lock state once

--- a/coralnet_toolbox/QtAnnotationWindow.py
+++ b/coralnet_toolbox/QtAnnotationWindow.py
@@ -1167,11 +1167,12 @@ class AnnotationWindow(BaseCanvas):
         # Load annotations for this virtual frame path
         self.load_annotations()
 
-        # Refresh scrub-bar tick marks (cheap; only runs on seek/pause, not playback)
-        self._update_video_annotation_marks()
-
-        # Update the player widget state
+        # Update the player widget state first so the slider range is valid
         self._video_player.update_state(frame_idx, video_raster.frame_count)
+
+        # Then refresh scrub-bar tick marks (cheap; only runs on seek/pause, not playback)
+        # AnnotatedSlider.paintEvent checks slider.maximum(), so ensure range set first.
+        self._update_video_annotation_marks()
 
     def _on_video_seek(self, frame_idx: int):
         """Handle slider seek: stop playback, display frame."""
@@ -1966,7 +1967,19 @@ class AnnotationWindow(BaseCanvas):
         super()._reset_z_channel_to_full_range(colormap_name)
     
     def update_current_image_path(self, image_path):
-        """Update the current image path being displayed."""
+        """Update the current image path being displayed.
+
+        For video rasters, do not override the virtual per-frame `current_image_path`
+        already set by `_display_video_frame`. The `ImageWindow` emits a raw
+        video path after calling `set_image`, so ignore that emission when
+        we're in active video mode to avoid losing the `::frame_N` suffix.
+        """
+        # If we're currently in video mode and the annotation window already has
+        # a per-frame virtual path, don't override it with the raw video path.
+        if getattr(self, '_active_video_raster', None) is not None:
+            if hasattr(self, 'current_image_path') and self.current_image_path and '::frame_' in str(self.current_image_path):
+                return
+
         self.current_image_path = image_path
         
     def update_mask_label_map(self):

--- a/coralnet_toolbox/QtAnnotationWindow.py
+++ b/coralnet_toolbox/QtAnnotationWindow.py
@@ -2989,6 +2989,12 @@ class AnnotationWindow(BaseCanvas):
             frame_keys = [k for k in list(self.image_annotations_dict.keys()) if k.startswith(prefix)]
             for frame_key in frame_keys:
                 self.delete_image_annotations(frame_key)
+            # If the canvas is currently displaying a frame of this video, force a full
+            # reload to guarantee stale graphics items are cleared from the scene.
+            if (self._active_video_raster is not None and
+                    self.current_image_path and
+                    self.current_image_path.startswith(prefix)):
+                self._display_video_frame(self._current_frame_idx)
             return
 
         # 1. Access label lock state once

--- a/coralnet_toolbox/QtImageWindow.py
+++ b/coralnet_toolbox/QtImageWindow.py
@@ -770,8 +770,20 @@ class ImageWindow(QWidget):
             image_path (str): Path to the image
             update_counts (bool): Whether to update the annotation counts in the label window
         """
-        annotations = self.annotation_window.get_image_annotations(image_path)
-        self.raster_manager.update_annotation_info(image_path, annotations)
+        # For video virtual frame paths (e.g. video.mp4::frame_5), resolve to the
+        # video path and aggregate annotations across all frames so the VideoRaster
+        # row in the table shows the correct total count.
+        if '::frame_' in image_path:
+            video_path = image_path.rsplit('::frame_', 1)[0]
+            prefix = video_path + '::frame_'
+            all_annotations = []
+            for key, anns in self.annotation_window.image_annotations_dict.items():
+                if key.startswith(prefix):
+                    all_annotations.extend(anns)
+            self.raster_manager.update_annotation_info(video_path, all_annotations)
+        else:
+            annotations = self.annotation_window.get_image_annotations(image_path)
+            self.raster_manager.update_annotation_info(image_path, annotations)
         
         if update_counts:
             self.main_window.label_window.update_annotation_count()
@@ -1117,9 +1129,9 @@ class ImageWindow(QWidget):
         if raster_under_cursor:
             is_checked = raster_under_cursor.checkbox_state
             if is_checked:
-                action_text = f"Uncheck {count} Highlighted Image{'s' if count > 1 else ''}"
+                action_text = f"Uncheck {count} Highlighted Raster{'s' if count > 1 else ''}"
             else:
-                action_text = f"Check {count} Highlighted Image{'s' if count > 1 else ''}"
+                action_text = f"Check {count} Highlighted Raster{'s' if count > 1 else ''}"
             toggle_check_action = context_menu.addAction(action_text)
             toggle_check_action.triggered.connect(lambda: self.on_toggle(not is_checked))
 
@@ -1127,7 +1139,7 @@ class ImageWindow(QWidget):
         
         # Add batch inference action
         batch_inference_action = context_menu.addAction(
-            f"Batch Inference ({count} Highlighted Image{'s' if count > 1 else ''})"
+            f"Batch Inference ({count} Highlighted Raster{'s' if count > 1 else ''})"
         )
         batch_inference_action.triggered.connect(
             lambda: self.open_batch_inference_dialog(highlighted_paths)
@@ -1140,7 +1152,7 @@ class ImageWindow(QWidget):
 
         # Add import cameras action
         import_cameras_action = cameras_menu.addAction(
-            f"Import Cameras for {count} Highlighted Image{'s' if count > 1 else ''}"
+            f"Import Cameras for {count} Highlighted Raster{'s' if count > 1 else ''}"
         )
         import_cameras_action.triggered.connect(lambda: self._open_import_cameras_for_highlighted(highlighted_paths))
 
@@ -1148,7 +1160,7 @@ class ImageWindow(QWidget):
 
         # Add remove cameras action
         remove_cameras_action = cameras_menu.addAction(
-            f"Remove Cameras from {count} Highlighted Image{'s' if count > 1 else ''}"
+            f"Remove Cameras from {count} Highlighted Raster{'s' if count > 1 else ''}"
         )
         remove_cameras_action.triggered.connect(lambda: self.remove_cameras_highlighted_images())
 
@@ -1157,7 +1169,7 @@ class ImageWindow(QWidget):
 
         # Add import z-channel action
         import_z_channel_action = z_channel_menu.addAction(
-            f"Import for {count} Highlighted Image{'s' if count > 1 else ''}"
+            f"Import for {count} Highlighted Raster{'s' if count > 1 else ''}"
         )
         import_z_channel_action.triggered.connect(
             lambda: self.import_z_channel_highlighted_images()
@@ -1165,7 +1177,7 @@ class ImageWindow(QWidget):
 
         # Add export z-channel action
         export_z_channel_action = z_channel_menu.addAction(
-            f"Export for {count} Highlighted Image{'s' if count > 1 else ''}"
+            f"Export for {count} Highlighted Raster{'s' if count > 1 else ''}"
         )
         export_z_channel_action.triggered.connect(
             lambda: self.export_z_channel_highlighted_images()
@@ -1175,7 +1187,7 @@ class ImageWindow(QWidget):
 
         # Add remove z-channel action
         remove_z_channel_action = z_channel_menu.addAction(
-            f"Remove from {count} Highlighted Image{'s' if count > 1 else ''}"
+            f"Remove from {count} Highlighted Raster{'s' if count > 1 else ''}"
         )
         remove_z_channel_action.triggered.connect(
             lambda: self.remove_z_channel_highlighted_images()
@@ -1184,10 +1196,10 @@ class ImageWindow(QWidget):
         context_menu.addSeparator()
 
         # Add delete actions
-        delete_images_action = context_menu.addAction(f"Delete {count} Highlighted Image{'s' if count > 1 else ''}")
+        delete_images_action = context_menu.addAction(f"Delete {count} Highlighted Raster{'s' if count > 1 else ''}")
         delete_images_action.triggered.connect(lambda: self.delete_highlighted_images())
         delete_annotations_action = context_menu.addAction(
-            f"Delete Annotations for {count} Highlighted Image{'s' if count > 1 else ''}"
+            f"Delete Annotations for {count} Highlighted Raster{'s' if count > 1 else ''}"
         )
         delete_annotations_action.triggered.connect(
             lambda: self.delete_highlighted_images_annotations()
@@ -1589,7 +1601,13 @@ class ImageWindow(QWidget):
                 # Restore signals
                 self.annotation_window.annotationCreated.connect(self.update_annotation_count)
                 self.annotation_window.annotationDeleted.connect(self.update_annotation_count)
-                
+
+                # Refresh video tick marks in case any deleted path was a video
+                try:
+                    self.annotation_window._update_video_annotation_marks()
+                except Exception:
+                    pass
+
                 # Close progress bar
                 if 'progress_bar' in locals() and progress_bar:
                     progress_bar.stop_progress()

--- a/coralnet_toolbox/QtImageWindow.py
+++ b/coralnet_toolbox/QtImageWindow.py
@@ -431,10 +431,53 @@ class ImageWindow(QWidget):
         # Connect annotation signals
         self.annotation_window.annotationCreated.connect(self.update_annotation_count)
         self.annotation_window.annotationDeleted.connect(self.update_annotation_count)
+        # Update raster table and counts when annotation labels change
+        self.annotation_window.annotationLabelChanged.connect(self.on_annotation_label_changed)
+        self.annotation_window.annotationsLabelsChanged.connect(self.on_annotations_labels_changed)
         
         # Connect our own signals
         self.imageLoaded.connect(self.on_image_loaded)
         self.filterChanged.connect(self.update_image_count_label)
+
+    def on_annotation_label_changed(self, ann_id, new_label=None):
+        """Handler called when a single annotation's label changes.
+
+        Looks up the annotation's image path and refreshes annotation info
+        for that raster so the table and tooltips update immediately.
+        """
+        try:
+            # ann_id may be None or invalid; guard defensively
+            if not ann_id:
+                return
+            annotation = self.annotation_window.annotations_dict.get(ann_id)
+            if annotation and getattr(annotation, 'image_path', None):
+                self.update_image_annotations(annotation.image_path)
+        except Exception:
+            pass
+
+    def on_annotations_labels_changed(self, changes):
+        """Handler for multiple label changes.
+
+        `changes` is expected to be a list of tuples: (annotation_id, old_label, new_label)
+        We aggregate affected image paths and update them once each.
+        """
+        try:
+            if not changes:
+                return
+            images_to_update = set()
+            for item in changes:
+                try:
+                    ann_id = item[0]
+                    annotation = self.annotation_window.annotations_dict.get(ann_id)
+                    if annotation and getattr(annotation, 'image_path', None):
+                        images_to_update.add(annotation.image_path)
+                except Exception:
+                    continue
+
+            for image_path in images_to_update:
+                self.update_image_annotations(image_path)
+        except Exception:
+            pass
         
     def schedule_filter(self):
         """Schedule filtering after a short delay to avoid excessive updates."""

--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -1327,6 +1327,9 @@ class MainWindow(QMainWindow):
         # ---------------------------------------------------------------------
         self.annotation_window.annotationCreated.connect(self.label_window.update_tooltips)
         self.annotation_window.annotationDeleted.connect(self.label_window.update_tooltips)
+        # Also refresh label tooltips when an annotation's label changes
+        self.annotation_window.annotationLabelChanged.connect(lambda *args: self.label_window.update_tooltips())
+        self.annotation_window.annotationsLabelsChanged.connect(lambda *args: self.label_window.update_tooltips())
 
         self.annotation_window.annotationCreated.connect(self.annotation_viewer_window.on_annotation_created)
         self.annotation_window.annotationsCreated.connect(self.annotation_viewer_window.on_annotations_created)

--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -2011,7 +2011,12 @@ class MainWindow(QMainWindow):
 
     def set_video_playback_tools_enabled(self, enabled: bool):
         """Enable or disable tools that are incompatible with live video playback."""
+        # Disable all, for now
         video_locked_actions = [
+            self.select_tool_action,
+            self.patch_tool_action,
+            self.rectangle_tool_action,
+            self.polygon_tool_action,
             self.brush_tool_action,
             self.fill_tool_action,
             self.dropper_tool_action,

--- a/coralnet_toolbox/QtMainWindow.py
+++ b/coralnet_toolbox/QtMainWindow.py
@@ -52,6 +52,7 @@ from coralnet_toolbox.WorkArea import WorkAreaManager as WorkAreaManagerDialog
 from coralnet_toolbox.IO import (
     ImportImages,
     ImportFrames,
+    ImportVideo,
     ImportLabels,
     ImportCoralNetLabels,
     ImportTagLabLabels,
@@ -284,6 +285,7 @@ class MainWindow(QMainWindow):
         self.export_geojson_annotations_dialog = ExportGeoJSONAnnotations(self)
         self.export_spatial_metrics_dialog = ExportSpatialMetrics(self)
         self.import_frames_dialog = ImportFrames(self)
+        self.import_video = ImportVideo(self)
         self.open_project_dialog = OpenProject(self)
         self.save_project_dialog = SaveProject(self)
 
@@ -363,6 +365,10 @@ class MainWindow(QMainWindow):
         self.import_frames_action = QAction("Frames from Video", self)
         self.import_frames_action.triggered.connect(self.open_import_frames_dialog)
         self.import_rasters_menu.addAction(self.import_frames_action)
+        # Import Video
+        self.import_video_action = QAction("Video File", self)
+        self.import_video_action.triggered.connect(self.import_video.import_video)
+        self.import_rasters_menu.addAction(self.import_video_action)
         
         # Labels submenu
         self.import_labels_menu = self.import_menu.addMenu("Labels")
@@ -1139,6 +1145,8 @@ class MainWindow(QMainWindow):
             self.annotation_dock.add_toolbar(self.annotation_window.create_top_toolbar())
         if hasattr(self.annotation_window, 'create_bottom_toolbar'):
             self.annotation_dock.add_toolbar(self.annotation_window.create_bottom_toolbar(), Qt.BottomToolBarArea)
+        if hasattr(self.annotation_window, 'create_video_toolbar'):
+            self.annotation_dock.add_toolbar(self.annotation_window.create_video_toolbar(), Qt.BottomToolBarArea)
 
         # Setup Image Dock using DockWrapper
         self.rasters_dock = DockWrapper("Rasters", "RastersDock", self.image_window, self)
@@ -2000,6 +2008,27 @@ class MainWindow(QMainWindow):
 
         # Emit to reset the tool
         self.toolChanged.emit(None)
+
+    def set_video_playback_tools_enabled(self, enabled: bool):
+        """Enable or disable tools that are incompatible with live video playback."""
+        video_locked_actions = [
+            self.brush_tool_action,
+            self.fill_tool_action,
+            self.dropper_tool_action,
+            self.erase_tool_action,
+            self.sam_tool_action,
+            self.see_anything_tool_action,
+            self.work_area_tool_action,
+        ]
+        for action in video_locked_actions:
+            action.setEnabled(enabled)
+        if not enabled:
+            # Untoggle any of these tools that are currently active
+            needs_reset = any(a.isChecked() for a in video_locked_actions)
+            for action in video_locked_actions:
+                action.setChecked(False)
+            if needs_reset:
+                self.toolChanged.emit(None)
 
     def handle_tool_changed(self, tool):
         """Update the toolbar UI to reflect the currently selected tool."""

--- a/coralnet_toolbox/QtVideoPlayer.py
+++ b/coralnet_toolbox/QtVideoPlayer.py
@@ -1,11 +1,61 @@
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import (QWidget, QHBoxLayout, QPushButton, QSlider, 
-                             QLabel, QStyle, QSizePolicy)
+from PyQt5.QtGui import QPainter, QPen, QColor
+from PyQt5.QtWidgets import (QWidget, QHBoxLayout, QPushButton, QSlider,
+                             QLabel, QStyle, QSizePolicy, QStyleOptionSlider)
 
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Classes
 # ----------------------------------------------------------------------------------------------------------------------
+
+
+class AnnotatedSlider(QSlider):
+    """
+    A QSlider subclass that draws small tick marks at frame positions that
+    contain annotations, giving a visual overview of annotated content.
+    """
+
+    def __init__(self, orientation, parent=None):
+        super().__init__(orientation, parent)
+        self._annotation_frames: set = set()
+
+    def set_annotation_frames(self, frames):
+        """Update the set of frame indices that have annotations and repaint."""
+        self._annotation_frames = set(frames)
+        self.update()
+
+    def paintEvent(self, event):
+        # Draw the standard slider first
+        super().paintEvent(event)
+
+        if not self._annotation_frames or self.maximum() <= 0:
+            return
+
+        # Use the style to find the exact groove rectangle
+        opt = QStyleOptionSlider()
+        self.initStyleOption(opt)
+        groove = self.style().subControlRect(
+            QStyle.CC_Slider, opt, QStyle.SC_SliderGroove, self
+        )
+
+        painter = QPainter(self)
+        tick_color = QColor(255, 190, 0, 220)   # amber / gold
+        pen = QPen(tick_color, 2)
+        painter.setPen(pen)
+
+        span = self.maximum() - self.minimum()
+        gx = groove.x()
+        gw = groove.width()
+        gy_top = groove.y()
+        gy_bot = groove.y() + groove.height()
+
+        for frame_idx in self._annotation_frames:
+            ratio = (frame_idx - self.minimum()) / span
+            x = gx + int(ratio * gw)
+            # Draw a short line that straddles the groove edges
+            painter.drawLine(x, gy_top - 2, x, gy_bot + 2)
+
+        painter.end()
 
 
 class VideoPlayerWidget(QWidget):
@@ -20,6 +70,8 @@ class VideoPlayerWidget(QWidget):
     seekChanged = pyqtSignal(int)       # Emits the new frame index
     nextFrameClicked = pyqtSignal()
     prevFrameClicked = pyqtSignal()
+    nextAnnotatedClicked = pyqtSignal()
+    prevAnnotatedClicked = pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -35,7 +87,15 @@ class VideoPlayerWidget(QWidget):
         layout.setContentsMargins(5, 0, 5, 5) # Small margins
         layout.setSpacing(10)
 
-        # --- 1. Step Backward Button ---
+        # --- 1. Jump to Previous Annotated Frame Button ---
+        self.btn_prev_annotated = QPushButton()
+        self.btn_prev_annotated.setIcon(self.style().standardIcon(QStyle.SP_MediaSeekBackward))
+        self.btn_prev_annotated.setToolTip("Jump to Previous Annotated Frame")
+        self.btn_prev_annotated.setFixedWidth(30)
+        self.btn_prev_annotated.clicked.connect(self.prevAnnotatedClicked.emit)
+        layout.addWidget(self.btn_prev_annotated)
+
+        # --- 2. Step Backward Button ---
         self.btn_prev = QPushButton()
         self.btn_prev.setIcon(self.style().standardIcon(QStyle.SP_MediaSkipBackward))
         self.btn_prev.setToolTip("Step Back 1 Frame")
@@ -43,15 +103,15 @@ class VideoPlayerWidget(QWidget):
         self.btn_prev.clicked.connect(self.prevFrameClicked.emit)
         layout.addWidget(self.btn_prev)
 
-        # --- 2. Play/Pause Button ---
+        # --- 3. Play/Pause Button ---
         self.btn_play = QPushButton()
         self.btn_play.setIcon(self.style().standardIcon(QStyle.SP_MediaPlay))
-        self.btn_play.setToolTip("Play / Pause (Spacebar)")
+        self.btn_play.setToolTip("Play / Pause")
         self.btn_play.setFixedWidth(30)
         self.btn_play.clicked.connect(self.toggle_playback_state)
         layout.addWidget(self.btn_play)
 
-        # --- 3. Step Forward Button ---
+        # --- 4. Step Forward Button ---
         self.btn_next = QPushButton()
         self.btn_next.setIcon(self.style().standardIcon(QStyle.SP_MediaSkipForward))
         self.btn_next.setToolTip("Step Forward 1 Frame")
@@ -59,8 +119,16 @@ class VideoPlayerWidget(QWidget):
         self.btn_next.clicked.connect(self.nextFrameClicked.emit)
         layout.addWidget(self.btn_next)
 
-        # --- 4. Scrubber Slider ---
-        self.slider = QSlider(Qt.Horizontal)
+        # --- 5. Jump to Next Annotated Frame Button ---
+        self.btn_next_annotated = QPushButton()
+        self.btn_next_annotated.setIcon(self.style().standardIcon(QStyle.SP_MediaSeekForward))
+        self.btn_next_annotated.setToolTip("Jump to Next Annotated Frame")
+        self.btn_next_annotated.setFixedWidth(30)
+        self.btn_next_annotated.clicked.connect(self.nextAnnotatedClicked.emit)
+        layout.addWidget(self.btn_next_annotated)
+
+        # --- 6. Scrubber Slider (AnnotatedSlider draws per-frame annotation ticks) ---
+        self.slider = AnnotatedSlider(Qt.Horizontal)
         self.slider.setToolTip("Seek Frame")
         # Connect sliderReleased/valueChanged depending on desired behavior.
         # using valueChanged allows dragging to scrub, but might be heavy if not optimized.
@@ -69,7 +137,7 @@ class VideoPlayerWidget(QWidget):
         self.slider.valueChanged.connect(self._on_slider_value_changed)
         layout.addWidget(self.slider)
 
-        # --- 5. Frame Counter Label ---
+        # --- 7. Frame Counter Label ---
         self.lbl_frame = QLabel("0 / 0")
         self.lbl_frame.setToolTip("Current Frame / Total Frames")
         self.lbl_frame.setMinimumWidth(80)
@@ -101,16 +169,20 @@ class VideoPlayerWidget(QWidget):
         """Force UI to 'Playing' state."""
         self.is_playing = True
         self.btn_play.setIcon(self.style().standardIcon(QStyle.SP_MediaPause))
-        # Disable step buttons while playing to prevent conflicts
+        # Disable step/jump buttons while playing to prevent conflicts
+        self.btn_prev_annotated.setEnabled(False)
         self.btn_prev.setEnabled(False)
         self.btn_next.setEnabled(False)
+        self.btn_next_annotated.setEnabled(False)
 
     def set_paused(self):
         """Force UI to 'Paused' state."""
         self.is_playing = False
         self.btn_play.setIcon(self.style().standardIcon(QStyle.SP_MediaPlay))
+        self.btn_prev_annotated.setEnabled(True)
         self.btn_prev.setEnabled(True)
         self.btn_next.setEnabled(True)
+        self.btn_next_annotated.setEnabled(True)
 
     def update_state(self, current_frame, total_frames):
         """
@@ -128,7 +200,17 @@ class VideoPlayerWidget(QWidget):
         # Update Label
         self.lbl_frame.setText(f"{current_frame} / {total_frames}")
 
+    def update_annotation_marks(self, frame_indices):
+        """
+        Update the amber tick marks on the scrub bar.
+
+        Args:
+            frame_indices (set[int]): Frame indices that contain at least one annotation.
+        """
+        self.slider.set_annotation_frames(frame_indices)
+
     def reset(self):
         """Reset controls to initial state."""
         self.set_paused()
         self.update_state(0, 0)
+        self.slider.set_annotation_frames(set())

--- a/coralnet_toolbox/Rasters/RasterManager.py
+++ b/coralnet_toolbox/Rasters/RasterManager.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Set
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtCore import QObject, pyqtSignal
 
-from coralnet_toolbox.Rasters import Raster
+from coralnet_toolbox.Rasters.QtRaster import Raster
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -68,14 +68,47 @@ class RasterManager(QObject):
     def get_raster(self, image_path: str) -> Optional[Raster]:
         """
         Get a raster by its image path.
+        Resolves virtual frame paths of the form 'video.mp4::frame_42' transparently.
         
         Args:
-            image_path (str): Path to the image file
+            image_path (str): Path to the image file, may be a virtual frame path
             
         Returns:
             Raster or None: The raster object if found, None otherwise
         """
+        # Resolve virtual video frame paths to the underlying video path
+        if '::frame_' in image_path:
+            video_path = image_path.rsplit('::frame_', 1)[0]
+            return self.rasters.get(video_path)
         return self.rasters.get(image_path)
+
+    def add_video_raster(self, video_path: str) -> bool:
+        """
+        Add a VideoRaster to the manager.
+
+        Args:
+            video_path (str): Path to the video file
+
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        if video_path in self.rasters:
+            return True  # Already exists
+
+        try:
+            # Import here to avoid circular imports at module level
+            from coralnet_toolbox.Rasters.VideoRaster import VideoRaster
+            raster = VideoRaster(video_path)
+
+            self.rasters[video_path] = raster
+            self.image_paths.append(video_path)
+
+            self.rasterAdded.emit(video_path)
+            return True
+
+        except Exception as e:
+            print(f"Error adding video raster {video_path}: {str(e)}")
+            return False
     
     def remove_raster(self, image_path: str) -> bool:
         """

--- a/coralnet_toolbox/Rasters/RasterManager.py
+++ b/coralnet_toolbox/Rasters/RasterManager.py
@@ -154,9 +154,14 @@ class RasterManager(QObject):
         Returns:
             bool: True if successful, False otherwise
         """
+        # Accept virtual frame paths like 'video.mp4::frame_42' and normalize
+        # them to the underlying video path so VideoRaster rows update properly.
+        if isinstance(image_path, str) and '::frame_' in image_path:
+            image_path = image_path.rsplit('::frame_', 1)[0]
+
         if image_path not in self.rasters:
             return False
-            
+
         self.rasters[image_path].update_annotation_info(annotations)
         self.rasterUpdated.emit(image_path)
         return True

--- a/coralnet_toolbox/Rasters/RasterTableModel.py
+++ b/coralnet_toolbox/Rasters/RasterTableModel.py
@@ -92,6 +92,34 @@ class RasterTableModel(QAbstractTableModel):
             elif index.column() == self.FILENAME_COL:
                 return raster.display_name
             elif index.column() == self.ANNOTATION_COUNT_COL:
+                # For VideoRaster: sum annotations across all virtual frame paths
+                try:
+                    from coralnet_toolbox.Rasters.VideoRaster import VideoRaster as _VR
+                    if isinstance(raster, _VR):
+                        prefix = raster.image_path + '::frame_'
+                        ann_dict = self.raster_manager.rasters  # just a hint; use annotation_manager
+                        # Sum via annotation_manager on the MainWindow if available
+                        try:
+                            import gc
+                            import weakref
+                            ann_manager = None
+                            # Walk parent chain to find annotation_manager
+                            for obj in gc.get_objects():
+                                if (hasattr(obj, 'image_annotations_dict') and
+                                        hasattr(obj, 'annotations_dict')):
+                                    ann_manager = obj
+                                    break
+                            if ann_manager is not None:
+                                total = sum(
+                                    len(v) for k, v in ann_manager.image_annotations_dict.items()
+                                    if k.startswith(prefix)
+                                )
+                                return str(total)
+                        except Exception:
+                            pass
+                        return str(raster.annotation_count)
+                except ImportError:
+                    pass
                 return str(raster.annotation_count)
                 
         elif role == Qt.TextAlignmentRole:
@@ -113,6 +141,22 @@ class RasterTableModel(QAbstractTableModel):
                 
         elif role == Qt.ToolTipRole:
             if index.column() == self.FILENAME_COL:
+                # VideoRaster: show video-specific info
+                try:
+                    from coralnet_toolbox.Rasters.VideoRaster import VideoRaster as _VR
+                    if isinstance(raster, _VR):
+                        duration_s = raster.frame_count / raster.fps if raster.fps > 0 else 0
+                        tooltip_parts = [
+                            f"<b>Path:</b> {path}",
+                            f"<b>Dimensions:</b> {raster.width}x{raster.height}",
+                            f"<b>FPS:</b> {raster.fps:.2f}",
+                            f"<b>Frames:</b> {raster.frame_count}",
+                            f"<b>Duration:</b> {duration_s:.1f}s",
+                        ]
+                        return "<br>".join(tooltip_parts)
+                except ImportError:
+                    pass
+
                 dimensions = raster.metadata.get('dimensions', f"{raster.width}x{raster.height}")
                 
                 tooltip_parts = [

--- a/coralnet_toolbox/Rasters/VideoRaster.py
+++ b/coralnet_toolbox/Rasters/VideoRaster.py
@@ -1,0 +1,356 @@
+import warnings
+import os
+from typing import Optional
+
+import cv2
+import numpy as np
+
+from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtCore import QObject
+
+from coralnet_toolbox.Rasters.QtRaster import Raster
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------------------------------------------------------
+
+VIDEO_EXTENSIONS = {'.mp4', '.avi', '.mov', '.mkv', '.webm', '.MP4', '.AVI', '.MOV', '.MKV', '.WEBM'}
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Classes
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class VideoRasterioShim:
+    """
+    Lightweight mock that satisfies the rasterio interface expected by annotation
+    cropping methods (create_cropped_image).  No actual rasterio I/O is performed.
+    """
+
+    def __init__(self, width: int, height: int):
+        self.width = width
+        self.height = height
+        self.count = 3  # RGB bands
+        self.closed = False  # Required: rasterio_to_cropped_image checks getattr(src, 'closed', True)
+        self._current_bgr: Optional[np.ndarray] = None  # (H, W, 3) BGR
+
+    def read(self, bands=None, window=None):
+        """
+        Return image data matching rasterio's read() interface.
+
+        Args:
+            bands: int (single band, 1-indexed) or list of ints, or None (all bands).
+            window: rasterio Window-like object with col_off, row_off, width, height.
+
+        Returns:
+            ndarray: (H, W) for a single band, (B, H, W) for multiple bands.
+        """
+        # Resolve crop region from window
+        if window is not None:
+            col = max(0, min(int(window.col_off), self.width))
+            row = max(0, min(int(window.row_off), self.height))
+            w = max(1, min(int(window.width), self.width - col))
+            h = max(1, min(int(window.height), self.height - row))
+        else:
+            col, row, w, h = 0, 0, self.width, self.height
+
+        if self._current_bgr is None:
+            # Blank frame
+            if isinstance(bands, int):
+                return np.zeros((h, w), dtype=np.uint8)
+            n = len(bands) if isinstance(bands, list) else 3
+            return np.zeros((n, h, w), dtype=np.uint8)
+
+        # Crop and convert BGR → RGB, produce (3, H, W)
+        rgb = self._current_bgr[:, :, ::-1]
+        cropped = rgb[row:row + h, col:col + w]       # (H, W, 3)
+        band_data = np.ascontiguousarray(np.transpose(cropped, (2, 0, 1)))  # (3, H, W)
+
+        if isinstance(bands, int):
+            return band_data[bands - 1]               # (H, W), 1-indexed
+        elif isinstance(bands, list):
+            indices = [b - 1 for b in bands]          # 1-indexed → 0-indexed
+            return band_data[indices]                  # (len(bands), H, W)
+        else:
+            return band_data                           # (3, H, W)
+
+    # Close is a no-op — required so Raster.cleanup() doesn't crash
+    def close(self):
+        pass
+
+
+class VideoRaster(Raster):
+    """
+    A Raster subclass backed by a video file instead of a static image.
+
+    Frames are addressed via virtual paths of the form:
+        /path/to/video.mp4::frame_42
+
+    The shim satisfies the rasterio interface so all annotation tools,
+    cropping helpers, and the confidence window work without modification.
+    """
+
+    def __init__(self, video_path: str):
+        # Open the video capture before calling super().__init__ so that
+        # load_rasterio() (called inside super().__init__) can use it.
+        self._cap = cv2.VideoCapture(video_path)
+        if not self._cap.isOpened():
+            raise ValueError(f"Cannot open video file: {video_path}")
+
+        self._video_fps = self._cap.get(cv2.CAP_PROP_FPS) or 25.0
+        self._video_frame_count = int(self._cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        self._video_width = int(self._cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        self._video_height = int(self._cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+        self._shim = VideoRasterioShim(self._video_width, self._video_height)
+        self._current_frame_idx: int = 0
+
+        # Thumbnail cache (populated on first call to get_thumbnail)
+        self._video_thumbnail: Optional[QImage] = None
+
+        # Call parent __init__ — it will call load_rasterio() which we override
+        super().__init__(video_path)
+
+    # ------------------------------------------------------------------
+    # Raster overrides
+    # ------------------------------------------------------------------
+
+    def load_rasterio(self) -> bool:
+        """Override: populate dimensions from cv2, set shim as rasterio_src."""
+        try:
+            if not hasattr(self, '_shim') or self._shim is None:
+                return False
+
+            self.width = self._video_width
+            self.height = self._video_height
+            self.channels = 3
+            self.shape = (self.height, self.width, self.channels)
+
+            self.metadata['dimensions'] = f"{self.width}x{self.height}"
+            self.metadata['bands'] = 3
+            self.metadata['fps'] = self._video_fps
+            self.metadata['frame_count'] = self._video_frame_count
+
+            # Point rasterio_src at the shim
+            self._rasterio_src = self._shim
+            return True
+
+        except Exception as e:
+            print(f"VideoRaster.load_rasterio error for {self.image_path}: {e}")
+            return False
+
+    @property
+    def rasterio_src(self):
+        """Always return the shim so annotations can crop from the current frame."""
+        return self._shim
+
+    # ------------------------------------------------------------------
+    # Video-specific properties
+    # ------------------------------------------------------------------
+
+    @property
+    def fps(self) -> float:
+        return self._video_fps
+
+    @property
+    def frame_count(self) -> int:
+        return self._video_frame_count
+
+    # ------------------------------------------------------------------
+    # Frame access
+    # ------------------------------------------------------------------
+
+    def get_frame(self, frame_idx: int) -> Optional[QImage]:
+        """
+        Seek to frame_idx, read BGR, update the shim, and return a QImage.
+        Returns None on failure.
+        """
+        if not self._cap or not self._cap.isOpened():
+            return None
+
+        frame_idx = max(0, min(frame_idx, self._video_frame_count - 1))
+
+        self._cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+        ret, bgr = self._cap.read()
+        if not ret or bgr is None:
+            return None
+
+        self._shim._current_bgr = bgr
+        self._current_frame_idx = frame_idx
+
+        return self._bgr_to_qimage(bgr)
+
+    def get_bgr_frame(self, frame_idx: int) -> Optional[np.ndarray]:
+        """Return a raw BGR numpy array for the given frame index."""
+        if not self._cap or not self._cap.isOpened():
+            return None
+
+        frame_idx = max(0, min(frame_idx, self._video_frame_count - 1))
+        self._cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+        ret, bgr = self._cap.read()
+        if not ret or bgr is None:
+            return None
+
+        self._shim._current_bgr = bgr
+        self._current_frame_idx = frame_idx
+        return bgr
+
+    def update_shim_for_frame(self, frame_idx: int):
+        """Update the shim's current BGR data without returning a QImage."""
+        if not self._cap or not self._cap.isOpened():
+            return
+
+        frame_idx = max(0, min(frame_idx, self._video_frame_count - 1))
+        self._cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+        ret, bgr = self._cap.read()
+        if ret and bgr is not None:
+            self._shim._current_bgr = bgr
+            self._current_frame_idx = frame_idx
+
+    # ------------------------------------------------------------------
+    # Raster image access overrides
+    # ------------------------------------------------------------------
+
+    def get_qimage(self) -> Optional[QImage]:
+        """Return frame 0 for display purposes (used by ImageWindow thumbnail)."""
+        return self.get_frame(0)
+
+    def get_thumbnail(self, longest_edge: int = 256) -> Optional[QImage]:
+        """Return a cached thumbnail of frame 0."""
+        if self._video_thumbnail is None:
+            frame_image = self.get_frame(0)
+            if frame_image is None:
+                return None
+            # Scale down
+            pixmap = QPixmap.fromImage(frame_image)
+            scaled = pixmap.scaled(
+                longest_edge, longest_edge,
+                aspectRatioMode=1,  # Qt.KeepAspectRatio
+                transformMode=1     # Qt.SmoothTransformation
+            )
+            self._video_thumbnail = scaled.toImage()
+
+        return self._video_thumbnail
+
+    def get_pixmap(self, longest_edge: Optional[int] = None) -> Optional[QPixmap]:
+        """Return a pixmap of frame 0."""
+        q_image = self.get_qimage()
+        if q_image is None:
+            return None
+        pixmap = QPixmap.fromImage(q_image)
+        if longest_edge is not None:
+            pixmap = pixmap.scaled(
+                longest_edge, longest_edge,
+                aspectRatioMode=1,
+                transformMode=1
+            )
+        return pixmap
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Extend base serialization with video-specific fields."""
+        data = super().to_dict()
+        data['type'] = 'VideoRaster'
+        data['fps'] = self._video_fps
+        data['frame_count'] = self._video_frame_count
+        return data
+
+    @classmethod
+    def from_dict(cls, raster_dict: dict) -> 'VideoRaster':
+        """Reconstruct a VideoRaster from a saved dictionary."""
+        video_path = raster_dict['path']
+        raster = cls(video_path)
+        state = raster_dict.get('state', {})
+        raster.checkbox_state = state.get('checkbox_state', False)
+        return raster
+
+    # ------------------------------------------------------------------
+    # Static helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def make_frame_path(video_path: str, frame_idx: int) -> str:
+        """Create the virtual image path for a specific frame."""
+        return f"{video_path}::frame_{frame_idx}"
+
+    @staticmethod
+    def parse_frame_path(path: str):
+        """
+        Parse a virtual frame path.
+        Returns (video_path, frame_idx) or (path, None) if not a virtual path.
+        """
+        if '::frame_' in path:
+            parts = path.rsplit('::frame_', 1)
+            try:
+                return parts[0], int(parts[1])
+            except (ValueError, IndexError):
+                pass
+        return path, None
+
+    @staticmethod
+    def is_video_path(path: str) -> bool:
+        """Return True if path has a recognised video extension."""
+        ext = os.path.splitext(path)[1]
+        return ext in VIDEO_EXTENSIONS
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def cleanup(self):
+        """Release cv2 resources before parent cleanup."""
+        if hasattr(self, '_cap') and self._cap is not None:
+            try:
+                self._cap.release()
+            except Exception:
+                pass
+            self._cap = None
+
+        self._video_thumbnail = None
+
+        # Clear shim reference (don't call close on parent's _rasterio_src
+        # because the base class cleanup() will try to close it)
+        self._rasterio_src = None
+        if hasattr(self, '_shim'):
+            self._shim = None
+
+        # Skip Raster.cleanup()'s attempt to close rasterio_src
+        # by calling QObject cleanup manually
+        try:
+            import gc
+            self._q_image = None
+            self._thumbnail = None
+            self.annotations = []
+            self.work_areas = []
+            self.delete_mask_annotation()
+            self.intrinsics = None
+            self.extrinsics = None
+            self.z_channel = None
+            gc.collect()
+        except Exception:
+            pass
+
+    def __del__(self):
+        try:
+            self.cleanup()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _bgr_to_qimage(bgr: np.ndarray) -> QImage:
+        """Convert a BGR numpy array to a QImage (RGB888)."""
+        rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+        h, w, ch = rgb.shape
+        bytes_per_line = ch * w
+        return QImage(rgb.data, w, h, bytes_per_line, QImage.Format_RGB888).copy()

--- a/coralnet_toolbox/Rasters/__init__.py
+++ b/coralnet_toolbox/Rasters/__init__.py
@@ -2,8 +2,9 @@
 
 # Import the Raster class here to expose it at the package level
 from coralnet_toolbox.Rasters.QtRaster import Raster
+from coralnet_toolbox.Rasters.VideoRaster import VideoRaster
 from coralnet_toolbox.Rasters.RasterManager import RasterManager
 from coralnet_toolbox.Rasters.ImageFilter import ImageFilter
 from coralnet_toolbox.Rasters.RasterTableModel import RasterTableModel
 
-__all__ = ['Raster', 'RasterManager', 'ImageFilter', 'RasterTableModel']
+__all__ = ['Raster', 'VideoRaster', 'RasterManager', 'ImageFilter', 'RasterTableModel']

--- a/coralnet_toolbox/Tools/QtPatchTool.py
+++ b/coralnet_toolbox/Tools/QtPatchTool.py
@@ -163,7 +163,7 @@ class PatchTool(Tool):
         if (self.cursor_annotation and 
             hasattr(self, '_last_annotation_size') and self._last_annotation_size == self.annotation_window.annotation_size):
             # Move the existing annotation to new position
-            self.cursor_annotation.setPos(scene_pos)
+            self.cursor_annotation.update_location(scene_pos)
         else:
             self.clear_cursor_annotation()
             self.create_cursor_annotation(scene_pos)


### PR DESCRIPTION
First step towards #257:
- Faster import of frames from video 
- Supports importing video files (MP4), which adds a video player in the AnnotationWindow; paused video treats frames exactly like individual image
- Annotations are currently not seen during the video playback, but tick marks on the scrubber and "go to" buttons make it easy to go to frames with annotations (hopefully future additions will allow basic graphics to display in real-time?
- Project can still be exported with video files and their annotations; treated as virtual image paths in the JSON / BIN project file
- Does not support exporting as YOLO datasets yet
- Does not support model predictions on multiple frames (BatchInference or otherwise)